### PR TITLE
Improve package quality: bug fixes, types, error handling, CI, tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: [main, "mpetty/**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  tests:
+    name: "Tests – PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}"
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["8.2", "8.3", "8.4"]
+        laravel: ["^10.0", "^11.0", "^12.0"]
+        exclude:
+          - php: "8.2"
+            laravel: "^12.0"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php }}"
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-update --no-interaction
+          composer update --no-interaction --prefer-dist --prefer-stable
+
+      - name: Run tests
+        run: vendor/bin/phpunit
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse
+
+  pint:
+    name: Laravel Pint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.phar
 composer.lock
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0] - Unreleased
+
+### Breaking Changes
+
+- **`Issues::attach()` return type changed** from `Issue` to `Attachments` — update any code that accesses the returned object
+- **`Issues::comment()` return type changed** from `Issue` to `Comment` — update any code that accesses the returned object
+- **`Field::getOptions()` removed** — use `Api\Fields::getFieldOptions(Field $field, string $projectKey, string $issueTypeName)` instead
+- **PHP minimum version raised** from `^8.0.2` to `^8.1`
+- **Laravel minimum version raised** from `^8.0||^9.0` to `^10.0||^11.0||^12.0`
+
+### Added
+
+- `Attachment` and `Attachments` models with full `make()` / `toArray()` support
+- `Comment` model with full `make()` / `toArray()` support
+- `Api\Fields::getFieldOptions(Field $field, string $projectKey, string $issueTypeName): array` — replaces `Field::getOptions()`
+- `toArray()` implemented on `Field`, `Fields`, `Search`, `User`, `Users`
+- HTTP error handling for status codes 422 (Unprocessable Entity), 500, 502, 503
+- CI matrix via GitHub Actions: PHP 8.2 / 8.3 / 8.4 × Laravel 10 / 11 / 12
+- PHPStan (level 6) and Pint (Laravel preset) configuration
+- Comprehensive test suite: 115 tests across models, API classes, exceptions, and the service provider
+
+### Fixed
+
+- `array_filter` on issue fields now preserves falsy non-null values (`0`, `''`, `false`) — previously dropped them
+- `HttpClientException` constructor now rewinds the response body stream before reading, preventing double-consume
+- Guzzle requests now use `['json' => $params]` instead of `['body' => json_encode($params)]`
+- Service provider now returns `null` when `jira.token` is not set instead of throwing a `RuntimeException`
+
+### Changed
+
+- All model getters and setters are now fully typed
+- `User::$active` is now strictly typed as `bool`
+- `HttpApi` constructor now accepts `GuzzleHttp\ClientInterface` (PSR) instead of the concrete `Client`
+- All `HttpClientException` factory methods now declare `self` as their return type
+
+## [1.0.5] - 2025-09-02
+
+### Added
+
+- `Issue::setCustomFieldByValue()` now accepts a `$is_multi_select` parameter to control single vs. multi-select field format
+
+## [1.0.4] - 2023-07-17
+
+### Fixed
+
+- Minor fix to `Issues.php`
+
+## [1.0.3] - 2023-06-xx
+
+### Changed
+
+- Changes to support Aletheia usage (CBE4-3814)
+- Removed hardcoded values; issue link URL is now generated from config
+
+## [1.0.2] - 2023-xx-xx
+
+### Changed
+
+- `composer.json` updates
+
+## [1.0.1] - 2023-xx-xx
+
+### Changed
+
+- Initial public release updates
+
+## [1.0.0] - 2023-xx-xx
+
+### Added
+
+- Initial release
+
+[Unreleased]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/1.1.0...HEAD
+[1.1.0]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/1.0.5...1.1.0
+[1.0.5]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.4...1.0.5
+[1.0.4]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/CaptureHigherEd/Laravel-Jira/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changes to support Aletheia usage (CBE4-3814)
 - Removed hardcoded values; issue link URL is now generated from config
 
 ## [1.0.2] - 2023-xx-xx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,16 @@ vendor/bin/phpstan analyse  # static analysis (level 6)
 vendor/bin/pint             # code style
 ```
 
+## After Every Change
+
+Always run these three commands before committing:
+
+```sh
+vendor/bin/phpunit          # must pass
+vendor/bin/phpstan analyse  # must show [OK] No errors
+vendor/bin/pint             # auto-fixes style; run --test to check only
+```
+
 ## Conventions
 
 - PHP 8.1+, strict types expected

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Laravel-Jira
+
+Laravel REST API v3 client for Jira (Atlassian Cloud).
+
+## Architecture
+
+Layered: `Jira` → `Api/` (HttpApi subclasses) → `Models/` (DTOs implementing `ApiResponse`)
+
+- **`Jira.php`** — entry point; exposes `issues()`, `fields()`, `users()`
+- **`Api/HttpApi.php`** — base class; wraps Guzzle, handles error dispatch and response hydration
+- **`Models/`** — DTOs with static `make(array $data = []): self` factory + `toArray(): array`
+- **`Providers/IntegrationServiceProvider.php`** — deferred Laravel service provider; auto-discovered
+- **`config/jira.php`** — reads `JIRA_API_EMAIL`, `JIRA_API_TOKEN`, `JIRA_API_DOMAIN`
+
+## Commands
+
+```sh
+composer install
+vendor/bin/phpunit          # tests
+vendor/bin/phpstan analyse  # static analysis (level 6)
+vendor/bin/pint             # code style
+```
+
+## Conventions
+
+- PHP 8.1+, strict types expected
+- Use `===` for comparisons, never `==`
+- The singleton returns `null` when `JIRA_API_EMAIL`/`JIRA_API_TOKEN` are not set — callers should null-check before use
+- HTTP errors throw `HttpClientException` — add new status codes to `handleErrors()` and as factory methods on the exception class
+- Keep DTOs free of service locator calls (`app()`) — business logic belongs in `Api/` classes

--- a/README.md
+++ b/README.md
@@ -1,60 +1,143 @@
 # Laravel Jira
 
-This Laravel package provides an interface for using Jira through its **API**.
+A Laravel package providing a clean client for the **Jira REST API v3** (Atlassian Cloud).
 
+## Requirements
+
+- PHP 8.1+
+- Laravel 10, 11, or 12
 
 ## Installation
 
-The Laravel package can be installed via [Composer](http://getcomposer.org) by requiring the
-`capturehighered/laravel-jira` package in your project's `composer.json`.
-
-```json
-{
-    "require": {
-        "capturehighered/laravel-jira": "~1.0"
-    }
-}
-```
-
-And running a composer update from your terminal:
 ```sh
-php composer.phar update
+composer require capturehighered/laravel-jira
 ```
 
-To use the Jira Package, you must register the provider when bootstrapping your Laravel 5 application.
-
-Find the `providers` key in your `config/app.php` and register the AWS Service Provider.
-
-```php
-    'providers' => array(
-        // ...
-        CaptureHigherEd\LaravelJira\Providers\IntegrationServiceProvider::class,
-    )
-```
+The service provider is auto-discovered via Laravel's package auto-discovery. No manual registration needed.
 
 ## Configuration
 
-By default, the package uses the following environment variables:
-```
-JIRA_API_EMAIL
-JIRA_API_TOKEN
-JIRA_API_DOMAIN
-```
-
-You must publish the config file for this to work:
+Publish the config file:
 
 ```sh
-php artisan vendor:publish
+php artisan vendor:publish --provider="CaptureHigherEd\LaravelJira\Providers\IntegrationServiceProvider"
 ```
+
+Add these to your `.env`:
+
+```env
+JIRA_API_EMAIL=you@example.com
+JIRA_API_TOKEN=your_atlassian_api_token
+JIRA_API_DOMAIN=https://yourcompany.atlassian.net
+```
+
+To generate an Atlassian API token: https://id.atlassian.com/manage-profile/security/api-tokens
+
+## Usage
+
+Resolve the `Jira` service from the container, or inject it:
+
+```php
+use CaptureHigherEd\LaravelJira\Jira;
+
+$jira = app(Jira::class);
+```
+
+### Issues
+
+```php
+// Search issues (JQL)
+$search = $jira->issues()->index(['jql' => 'project = CBE4 AND status = "To Do"']);
+foreach ($search->getIssues() as $issue) {
+    echo $issue->getKey() . ': ' . $issue->getSummary();
+}
+
+// Get a single issue
+$issue = $jira->issues()->show('CBE4-123');
+echo $issue->getLink(); // https://yourcompany.atlassian.net/browse/CBE4-123
+
+// Create an issue
+use CaptureHigherEd\LaravelJira\Models\Issue;
+
+$payload = Issue::make()
+    ->setProjectByKey('CBE4')
+    ->setIssueTypeByName('Bug')
+    ->setSummary('Something is broken')
+    ->setDescription([/* Atlassian Document Format content */]);
+
+$created = $jira->issues()->create($payload->toArray());
+
+// Update an issue
+$jira->issues()->update('CBE4-123', ['fields' => ['summary' => 'Updated title']]);
+
+// Add a comment
+$comment = $jira->issues()->comment('CBE4-123', [
+    'body' => ['type' => 'doc', 'version' => 1, 'content' => [
+        ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Hello!']]]
+    ]]
+]);
+
+// Attach a file
+$attachment = $jira->issues()->attach('CBE4-123', [
+    ['name' => 'file', 'contents' => fopen('/path/to/file.pdf', 'r'), 'filename' => 'file.pdf']
+]);
+
+// Delete an issue
+$jira->issues()->delete('CBE4-123');
+```
+
+### Fields
+
+```php
+// Get all fields
+$fields = $jira->fields()->index();
+
+// Get only custom fields
+foreach ($fields->getCustomFields() as $field) {
+    echo $field->getId() . ': ' . $field->getName();
+}
+
+// Look up a custom field ID by name
+$fieldId = $fields->getCustomFieldId('My Custom Field');
+
+// Get allowed values for a field (project + issue type context)
+$field = $fields->getCustomField('Priority');
+$options = $jira->fields()->getFieldOptions($field, 'CBE4', 'Bug');
+// ['High' => 'High', 'Medium' => 'Medium', 'Low' => 'Low']
+```
+
+### Users
+
+```php
+// Get all users
+$users = $jira->users()->index();
+
+// Get active users only
+$activeUsers = $users->getActiveUsers();
+
+foreach ($activeUsers as $user) {
+    echo $user->getKey() . ': ' . $user->getName() . ' <' . $user->getEmail() . '>';
+}
+```
+
+## Error Handling
+
+All HTTP errors throw `CaptureHigherEd\LaravelJira\Exception\HttpClientException`:
+
+```php
+use CaptureHigherEd\LaravelJira\Exception\HttpClientException;
+
+try {
+    $issue = $jira->issues()->show('INVALID-999');
+} catch (HttpClientException $e) {
+    echo $e->getResponseCode(); // 404
+    echo $e->getMessage();      // The endpoint you have tried to access does not exist.
+    print_r($e->getResponseBody());
+}
+```
+
+Covered status codes: 400, 401, 402, 403, 404, 409, 413, 422, 429, 500, 502, 503.
 
 ## License
 
-This software is licensed under the [MIT license](http://opensource.org/licenses/MIT)
-
-## Versioning
-
-This project follows the [Semantic Versioning](http://semver.org/)
-
-## Thanks
-
-Code originated by https://github.com/mpetty
+[MIT](LICENSE.md)

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,45 @@
 {
-  "name": "capturehighered/laravel-jira",
-  "description": "Laravel Jira API integration",
-  "keywords": [
-    "laravel",
-    "jira"
-  ],
-  "homepage": "https://capturehighered.com",
-  "type": "project",
-  "license": "MIT",
-  "require": {
-    "php": "^8.2",
-    "laravel/framework": ">=9.0"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^10.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "CaptureHigherEd\\LaravelJira\\": "src/CaptureHigherEd/LaravelJira"
-    }
-  },
-  "config": {
-      "sort-packages": true,
-      "allow-plugins": {
-          "composer/package-versions-deprecated": true
-      }
-  },
-  "minimum-stability": "stable",
-  "prefer-stable": true
+    "name": "capturehighered/laravel-jira",
+    "description": "Laravel Jira REST API v3 client",
+    "keywords": [
+        "laravel",
+        "jira",
+        "atlassian"
+    ],
+    "homepage": "https://capturehighered.com",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.1",
+        "guzzlehttp/guzzle": "^7.0",
+        "laravel/framework": "^10.0||^11.0||^12.0"
+    },
+    "require-dev": {
+        "laravel/pint": "^1.0",
+        "orchestra/testbench": "^8.0||^9.0||^10.0",
+        "phpstan/phpstan": "^1.0",
+        "phpunit/phpunit": "^10.0||^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "CaptureHigherEd\\LaravelJira\\": "src/CaptureHigherEd/LaravelJira"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "CaptureHigherEd\\LaravelJira\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "CaptureHigherEd\\LaravelJira\\Providers\\IntegrationServiceProvider"
+            ]
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: 6
+    paths:
+        - src

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,7 @@
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>
+            <exclude>./tests/Concerns/</exclude>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+<phpunit bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
 >

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,3 @@
+{
+    "preset": "laravel"
+}

--- a/src/CaptureHigherEd/LaravelJira/Api/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Fields.php
@@ -2,6 +2,7 @@
 
 namespace CaptureHigherEd\LaravelJira\Api;
 
+use CaptureHigherEd\LaravelJira\Models\Field;
 use CaptureHigherEd\LaravelJira\Models\Fields as ModelsFields;
 
 /**
@@ -17,5 +18,36 @@ class Fields extends HttpApi
         $response = $this->httpGet('field', $params);
 
         return $this->hydrateResponse($response, ModelsFields::class);
+    }
+
+    /**
+     * Get allowed values for a specific field within a project and issue type.
+     *
+     * @param  Field  $field           The field to look up options for
+     * @param  string $projectKey      The Jira project key (e.g. "CBE4")
+     * @param  string $issueTypeName   The issue type name (e.g. "Bug")
+     * @return array<string, string>   Map of value => value for the allowed options
+     */
+    public function getFieldOptions(Field $field, string $projectKey, string $issueTypeName): array
+    {
+        $meta = $this->hydrateResponse(
+            $this->httpGet('issue/createmeta', ['expand' => 'projects.issuetypes.fields'])
+        );
+
+        foreach ($meta['projects'] as $project) {
+            if ($project['key'] === $projectKey) {
+                foreach ($project['issuetypes'] as $issueType) {
+                    if ($issueType['name'] === $issueTypeName) {
+                        foreach ($issueType['fields'] as $fieldKey => $fieldData) {
+                            if ($fieldKey === $field->getKey()) {
+                                return collect($fieldData['allowedValues'])->pluck('value', 'value')->toArray();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return [];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Api/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Fields.php
@@ -13,6 +13,8 @@ class Fields extends HttpApi
     /**
      * Get all fields
      *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-rest-api-3-field-get
+     *
      * @param  array<string, mixed>  $params
      */
     public function index(array $params = []): ModelsFields
@@ -24,6 +26,9 @@ class Fields extends HttpApi
 
     /**
      * Get allowed values for a specific field within a project and issue type.
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-createmeta-get
+     * @deprecated Relies on the deprecated GET /issue/createmeta endpoint. Use Issues::getCreateMetaFields() to retrieve field metadata for a specific project and issue type.
      *
      * @param  Field  $field  The field to look up options for
      * @param  string  $projectKey  The Jira project key (e.g. "CBE4")

--- a/src/CaptureHigherEd/LaravelJira/Api/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Fields.php
@@ -13,6 +13,9 @@ class Fields extends HttpApi
     /**
      * Get all fields
      */
+    /**
+     * @param  array<string, mixed>  $params
+     */
     public function index(array $params = []): ModelsFields
     {
         $response = $this->httpGet('field', $params);
@@ -23,13 +26,14 @@ class Fields extends HttpApi
     /**
      * Get allowed values for a specific field within a project and issue type.
      *
-     * @param  Field  $field           The field to look up options for
-     * @param  string $projectKey      The Jira project key (e.g. "CBE4")
-     * @param  string $issueTypeName   The issue type name (e.g. "Bug")
-     * @return array<string, string>   Map of value => value for the allowed options
+     * @param  Field  $field  The field to look up options for
+     * @param  string  $projectKey  The Jira project key (e.g. "CBE4")
+     * @param  string  $issueTypeName  The issue type name (e.g. "Bug")
+     * @return array<string, string> Map of value => value for the allowed options
      */
     public function getFieldOptions(Field $field, string $projectKey, string $issueTypeName): array
     {
+        /** @var array<string, mixed> $meta */
         $meta = $this->hydrateResponse(
             $this->httpGet('issue/createmeta', ['expand' => 'projects.issuetypes.fields'])
         );
@@ -40,7 +44,10 @@ class Fields extends HttpApi
                     if ($issueType['name'] === $issueTypeName) {
                         foreach ($issueType['fields'] as $fieldKey => $fieldData) {
                             if ($fieldKey === $field->getKey()) {
-                                return collect($fieldData['allowedValues'])->pluck('value', 'value')->toArray();
+                                /** @var array<mixed> $allowedValues */
+                                $allowedValues = $fieldData['allowedValues'];
+
+                                return collect($allowedValues)->pluck('value', 'value')->toArray();
                             }
                         }
                     }

--- a/src/CaptureHigherEd/LaravelJira/Api/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Fields.php
@@ -12,8 +12,7 @@ class Fields extends HttpApi
 {
     /**
      * Get all fields
-     */
-    /**
+     *
      * @param  array<string, mixed>  $params
      */
     public function index(array $params = []): ModelsFields

--- a/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
@@ -112,7 +112,7 @@ abstract class HttpApi
             return $class ? $class::make([]) : [];
         }
 
-        $data = json_decode($body, true);
+        $data = json_decode($body, true) ?? [];
 
         if (! $class) {
             return $data;

--- a/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
@@ -2,19 +2,23 @@
 
 namespace CaptureHigherEd\LaravelJira\Api;
 
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use CaptureHigherEd\LaravelJira\Exception\HttpClientException;
 
 abstract class HttpApi
 {
-    protected Client $httpClient;
+    protected ClientInterface $httpClient;
 
-    public function __construct(Client $httpClient)
+    public function __construct(ClientInterface $httpClient)
     {
         $this->httpClient = $httpClient;
     }
 
+    /**
+     * @param  string               $path        Relative API path
+     * @param  array<string, mixed> $parameters  Query string parameters
+     */
     protected function httpGet(string $path, array $parameters = []): ResponseInterface
     {
         $response = $this->httpClient->get($path, ['query' => $parameters]);
@@ -22,14 +26,22 @@ abstract class HttpApi
         return $response;
     }
 
+    /**
+     * @param  string               $path        Relative API path
+     * @param  array<string, mixed> $parameters  JSON request body
+     */
     protected function httpPost(string $path, array $parameters = []): ResponseInterface
     {
-        $response = $this->httpClient->post($path, ['body' => json_encode($parameters)]);
+        $response = $this->httpClient->post($path, ['json' => $parameters]);
 
         return $response;
     }
 
-    protected function httpPostWithAttachments(string $path, array $multipart = [], array $headers = []): ResponseInterface
+    /**
+     * @param  string                        $path       Relative API path
+     * @param  array<int, array<string,mixed>> $multipart Guzzle multipart form data
+     */
+    protected function httpPostWithAttachments(string $path, array $multipart = []): ResponseInterface
     {
         $response = $this->httpClient->post($path, ['multipart' => $multipart, 'headers' => [
             'Accept' => 'application/json',
@@ -39,13 +51,20 @@ abstract class HttpApi
         return $response;
     }
 
+    /**
+     * @param  string               $path        Relative API path
+     * @param  array<string, mixed> $parameters  JSON request body
+     */
     protected function httpPut(string $path, array $parameters = []): ResponseInterface
     {
-        $response = $this->httpClient->put($path, ['body' => json_encode($parameters)]);
+        $response = $this->httpClient->put($path, ['json' => $parameters]);
 
         return $response;
     }
 
+    /**
+     * @param  string $path  Relative API path
+     */
     protected function httpDelete(string $path): ResponseInterface
     {
         $response = $this->httpClient->delete($path);
@@ -72,8 +91,14 @@ abstract class HttpApi
                 throw HttpClientException::conflict($response);
             case 413:
                 throw HttpClientException::payloadTooLarge($response);
+            case 422:
+                throw HttpClientException::unprocessableEntity($response);
             case 429:
                 throw HttpClientException::tooManyRequests($response);
+            case 500:
+            case 502:
+            case 503:
+                throw HttpClientException::serverError($response);
             default:
                 throw HttpClientException::unknown($response);
         }
@@ -81,11 +106,23 @@ abstract class HttpApi
 
     protected function hydrateResponse(ResponseInterface $response, ?string $class = null): mixed
     {
-        $data = json_decode($response->getBody(), true);
+        $statusCode = $response->getStatusCode();
 
-        if (!in_array($response->getStatusCode(), [200, 201, 202, 204], true)) {
+        if (!in_array($statusCode, [200, 201, 202, 204], true)) {
             $this->handleErrors($response);
         }
+
+        if ($statusCode === 204) {
+            return $class ? $class::make([]) : [];
+        }
+
+        $body = (string) $response->getBody();
+
+        if ($body === '') {
+            return $class ? $class::make([]) : [];
+        }
+
+        $data = json_decode($body, true);
 
         if (!$class) {
             return $data;

--- a/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
@@ -2,9 +2,9 @@
 
 namespace CaptureHigherEd\LaravelJira\Api;
 
+use CaptureHigherEd\LaravelJira\Exception\HttpClientException;
 use GuzzleHttp\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
-use CaptureHigherEd\LaravelJira\Exception\HttpClientException;
 
 abstract class HttpApi
 {
@@ -16,60 +16,50 @@ abstract class HttpApi
     }
 
     /**
-     * @param  string               $path        Relative API path
-     * @param  array<string, mixed> $parameters  Query string parameters
+     * @param  string  $path  Relative API path
+     * @param  array<string, mixed>  $parameters  Query string parameters
      */
     protected function httpGet(string $path, array $parameters = []): ResponseInterface
     {
-        $response = $this->httpClient->get($path, ['query' => $parameters]);
-
-        return $response;
+        return $this->httpClient->request('GET', $path, ['query' => $parameters]);
     }
 
     /**
-     * @param  string               $path        Relative API path
-     * @param  array<string, mixed> $parameters  JSON request body
+     * @param  string  $path  Relative API path
+     * @param  array<string, mixed>  $parameters  JSON request body
      */
     protected function httpPost(string $path, array $parameters = []): ResponseInterface
     {
-        $response = $this->httpClient->post($path, ['json' => $parameters]);
-
-        return $response;
+        return $this->httpClient->request('POST', $path, ['json' => $parameters]);
     }
 
     /**
-     * @param  string                        $path       Relative API path
-     * @param  array<int, array<string,mixed>> $multipart Guzzle multipart form data
+     * @param  string  $path  Relative API path
+     * @param  array<int, array<string, mixed>>  $multipart  Guzzle multipart form data
      */
     protected function httpPostWithAttachments(string $path, array $multipart = []): ResponseInterface
     {
-        $response = $this->httpClient->post($path, ['multipart' => $multipart, 'headers' => [
+        return $this->httpClient->request('POST', $path, ['multipart' => $multipart, 'headers' => [
             'Accept' => 'application/json',
-            'X-Atlassian-Token' => 'no-check'
+            'X-Atlassian-Token' => 'no-check',
         ]]);
-
-        return $response;
     }
 
     /**
-     * @param  string               $path        Relative API path
-     * @param  array<string, mixed> $parameters  JSON request body
+     * @param  string  $path  Relative API path
+     * @param  array<string, mixed>  $parameters  JSON request body
      */
     protected function httpPut(string $path, array $parameters = []): ResponseInterface
     {
-        $response = $this->httpClient->put($path, ['json' => $parameters]);
-
-        return $response;
+        return $this->httpClient->request('PUT', $path, ['json' => $parameters]);
     }
 
     /**
-     * @param  string $path  Relative API path
+     * @param  string  $path  Relative API path
      */
     protected function httpDelete(string $path): ResponseInterface
     {
-        $response = $this->httpClient->delete($path);
-
-        return $response;
+        return $this->httpClient->request('DELETE', $path);
     }
 
     protected function handleErrors(ResponseInterface $response): void
@@ -108,7 +98,7 @@ abstract class HttpApi
     {
         $statusCode = $response->getStatusCode();
 
-        if (!in_array($statusCode, [200, 201, 202, 204], true)) {
+        if (! in_array($statusCode, [200, 201, 202, 204], true)) {
             $this->handleErrors($response);
         }
 
@@ -124,7 +114,7 @@ abstract class HttpApi
 
         $data = json_decode($body, true);
 
-        if (!$class) {
+        if (! $class) {
             return $data;
         }
 

--- a/src/CaptureHigherEd/LaravelJira/Api/Issues.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Issues.php
@@ -2,6 +2,8 @@
 
 namespace CaptureHigherEd\LaravelJira\Api;
 
+use CaptureHigherEd\LaravelJira\Models\Attachments;
+use CaptureHigherEd\LaravelJira\Models\Comment;
 use CaptureHigherEd\LaravelJira\Models\Issue;
 use CaptureHigherEd\LaravelJira\Models\Search;
 
@@ -50,26 +52,24 @@ class Issues extends HttpApi
      * Attach a file
      *
      * @param  array<int, array<string, mixed>>  $params
-     * @return array<mixed>
      */
-    public function attach(string $issueId, array $params = []): array
+    public function attach(string $issueId, array $params = []): Attachments
     {
         $response = $this->httpPostWithAttachments(sprintf('issue/%s/attachments', $issueId), $params);
 
-        return $this->hydrateResponse($response);
+        return $this->hydrateResponse($response, Attachments::class);
     }
 
     /**
      * Add a comment
      *
      * @param  array<string, mixed>  $params
-     * @return array<mixed>
      */
-    public function comment(string $issueId, array $params = []): array
+    public function comment(string $issueId, array $params = []): Comment
     {
         $response = $this->httpPost(sprintf('issue/%s/comment', $issueId), $params);
 
-        return $this->hydrateResponse($response);
+        return $this->hydrateResponse($response, Comment::class);
     }
 
     /**

--- a/src/CaptureHigherEd/LaravelJira/Api/Issues.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Issues.php
@@ -13,7 +13,7 @@ class Issues extends HttpApi
     /**
      * Get all issues
      */
-    public function index(array $params = [])
+    public function index(array $params = []): Search
     {
         $response = $this->httpGet('search', $params);
 
@@ -43,21 +43,21 @@ class Issues extends HttpApi
     /**
      * Attach a file
      */
-    public function attach(string $issueId, array $params = []): Issue
+    public function attach(string $issueId, array $params = []): array
     {
         $response = $this->httpPostWithAttachments(sprintf('issue/%s/attachments', $issueId), $params);
 
-        return $this->hydrateResponse($response, Issue::class);
+        return $this->hydrateResponse($response);
     }
 
     /**
      * Add a comment
      */
-    public function comment(string $issueId, array $params = []): Issue
+    public function comment(string $issueId, array $params = []): array
     {
         $response = $this->httpPost(sprintf('issue/%s/comment', $issueId), $params);
 
-        return $this->hydrateResponse($response, Issue::class);
+        return $this->hydrateResponse($response);
     }
 
     /**
@@ -73,7 +73,7 @@ class Issues extends HttpApi
     /**
      * Get creation metadata
      */
-    public function getCreateMeta(array $params = [])
+    public function getCreateMeta(array $params = []): array
     {
         $response = $this->httpGet('issue/createmeta', $params);
 
@@ -83,7 +83,7 @@ class Issues extends HttpApi
     /**
      * Delete an issue
      */
-    public function delete(string $issueId)
+    public function delete(string $issueId): array
     {
         $response = $this->httpDelete(sprintf('issue/%s', $issueId));
 

--- a/src/CaptureHigherEd/LaravelJira/Api/Issues.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Issues.php
@@ -12,6 +12,8 @@ class Issues extends HttpApi
 {
     /**
      * Get all issues
+     *
+     * @param  array<string, mixed>  $params
      */
     public function index(array $params = []): Search
     {
@@ -22,6 +24,8 @@ class Issues extends HttpApi
 
     /**
      * Get an issue
+     *
+     * @param  array<string, mixed>  $params
      */
     public function show(string $issueId, array $params = []): Issue
     {
@@ -32,6 +36,8 @@ class Issues extends HttpApi
 
     /**
      * Create an issue
+     *
+     * @param  array<string, mixed>  $params
      */
     public function create(array $params = []): Issue
     {
@@ -42,6 +48,9 @@ class Issues extends HttpApi
 
     /**
      * Attach a file
+     *
+     * @param  array<int, array<string, mixed>>  $params
+     * @return array<mixed>
      */
     public function attach(string $issueId, array $params = []): array
     {
@@ -52,6 +61,9 @@ class Issues extends HttpApi
 
     /**
      * Add a comment
+     *
+     * @param  array<string, mixed>  $params
+     * @return array<mixed>
      */
     public function comment(string $issueId, array $params = []): array
     {
@@ -62,6 +74,8 @@ class Issues extends HttpApi
 
     /**
      * Update an issue
+     *
+     * @param  array<string, mixed>  $params
      */
     public function update(string $issueId, array $params = []): Issue
     {
@@ -72,6 +86,9 @@ class Issues extends HttpApi
 
     /**
      * Get creation metadata
+     *
+     * @param  array<string, mixed>  $params
+     * @return array<mixed>
      */
     public function getCreateMeta(array $params = []): array
     {
@@ -82,6 +99,8 @@ class Issues extends HttpApi
 
     /**
      * Delete an issue
+     *
+     * @return array<mixed>
      */
     public function delete(string $issueId): array
     {

--- a/src/CaptureHigherEd/LaravelJira/Api/Issues.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Issues.php
@@ -4,7 +4,9 @@ namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Models\Attachments;
 use CaptureHigherEd\LaravelJira\Models\Comment;
+use CaptureHigherEd\LaravelJira\Models\FieldMetas;
 use CaptureHigherEd\LaravelJira\Models\Issue;
+use CaptureHigherEd\LaravelJira\Models\IssueTypes;
 use CaptureHigherEd\LaravelJira\Models\Search;
 
 /**
@@ -15,17 +17,21 @@ class Issues extends HttpApi
     /**
      * Get all issues
      *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-get
+     *
      * @param  array<string, mixed>  $params
      */
     public function index(array $params = []): Search
     {
-        $response = $this->httpGet('search', $params);
+        $response = $this->httpGet('search/jql', $params);
 
         return $this->hydrateResponse($response, Search::class);
     }
 
     /**
      * Get an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-get
      *
      * @param  array<string, mixed>  $params
      */
@@ -39,6 +45,8 @@ class Issues extends HttpApi
     /**
      * Create an issue
      *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post
+     *
      * @param  array<string, mixed>  $params
      */
     public function create(array $params = []): Issue
@@ -50,6 +58,8 @@ class Issues extends HttpApi
 
     /**
      * Attach a file
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-issue-issueidorkey-attachments-post
      *
      * @param  array<int, array<string, mixed>>  $params
      */
@@ -63,6 +73,8 @@ class Issues extends HttpApi
     /**
      * Add a comment
      *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-post
+     *
      * @param  array<string, mixed>  $params
      */
     public function comment(string $issueId, array $params = []): Comment
@@ -75,17 +87,23 @@ class Issues extends HttpApi
     /**
      * Update an issue
      *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put
+     *
      * @param  array<string, mixed>  $params
+     * @return array<mixed>
      */
-    public function update(string $issueId, array $params = []): Issue
+    public function update(string $issueId, array $params = []): array
     {
         $response = $this->httpPut(sprintf('issue/%s', $issueId), $params);
 
-        return $this->hydrateResponse($response, Issue::class);
+        return $this->hydrateResponse($response);
     }
 
     /**
      * Get creation metadata
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-createmeta-get
+     * @deprecated Use getCreateMetaIssueTypes() and getCreateMetaFields() instead.
      *
      * @param  array<string, mixed>  $params
      * @return array<mixed>
@@ -98,7 +116,40 @@ class Issues extends HttpApi
     }
 
     /**
+     * Get issue types for a project's create metadata.
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-createmeta-projectidorkey-issuetypes-get
+     *
+     * @param  array<string, mixed>  $params  Query params (startAt, maxResults)
+     */
+    public function getCreateMetaIssueTypes(string $projectKey, array $params = []): IssueTypes
+    {
+        $response = $this->httpGet(sprintf('issue/createmeta/%s/issuetypes', $projectKey), $params);
+
+        return $this->hydrateResponse($response, IssueTypes::class);
+    }
+
+    /**
+     * Get field metadata for a specific project and issue type.
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-createmeta-projectidorkey-issuetypes-issuetypeid-get
+     *
+     * @param  array<string, mixed>  $params  Query params (startAt, maxResults)
+     */
+    public function getCreateMetaFields(string $projectKey, string $issueTypeId, array $params = []): FieldMetas
+    {
+        $response = $this->httpGet(
+            sprintf('issue/createmeta/%s/issuetypes/%s', $projectKey, $issueTypeId),
+            $params
+        );
+
+        return $this->hydrateResponse($response, FieldMetas::class);
+    }
+
+    /**
      * Delete an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-delete
      *
      * @return array<mixed>
      */

--- a/src/CaptureHigherEd/LaravelJira/Api/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Users.php
@@ -5,14 +5,14 @@ namespace CaptureHigherEd\LaravelJira\Api;
 use CaptureHigherEd\LaravelJira\Models\Users as ModelsUsers;
 
 /**
- * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-group-issue-fields
+ * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/#api-group-users
  */
 class Users extends HttpApi
 {
     /**
-     * Get all fields
+     * Get all users
      */
-    public function index(array $params = ['maxResults' => 1000]): ModelsUsers
+    public function index(array $params = []): ModelsUsers
     {
         $response = $this->httpGet('users', $params);
 

--- a/src/CaptureHigherEd/LaravelJira/Api/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Users.php
@@ -12,6 +12,8 @@ class Users extends HttpApi
     /**
      * Get all users
      *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/#api-rest-api-3-users-get
+     *
      * @param  array<string, mixed>  $params
      */
     public function index(array $params = ['maxResults' => 1000]): ModelsUsers

--- a/src/CaptureHigherEd/LaravelJira/Api/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Users.php
@@ -14,7 +14,7 @@ class Users extends HttpApi
      *
      * @param  array<string, mixed>  $params
      */
-    public function index(array $params = []): ModelsUsers
+    public function index(array $params = ['maxResults' => 1000]): ModelsUsers
     {
         $response = $this->httpGet('users', $params);
 

--- a/src/CaptureHigherEd/LaravelJira/Api/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Users.php
@@ -11,6 +11,8 @@ class Users extends HttpApi
 {
     /**
      * Get all users
+     *
+     * @param  array<string, mixed>  $params
      */
     public function index(array $params = []): ModelsUsers
     {

--- a/src/CaptureHigherEd/LaravelJira/Exception/CustomFieldDoesNotExistException.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/CustomFieldDoesNotExistException.php
@@ -2,7 +2,14 @@
 
 namespace CaptureHigherEd\LaravelJira\Exception;
 
-
 final class CustomFieldDoesNotExistException extends \RuntimeException
 {
+    public function __construct(string $fieldName = '')
+    {
+        $message = $fieldName
+            ? "Custom field \"{$fieldName}\" does not exist."
+            : 'Custom field does not exist.';
+
+        parent::__construct($message);
+    }
 }

--- a/src/CaptureHigherEd/LaravelJira/Exception/HttpClientException.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/HttpClientException.php
@@ -26,7 +26,7 @@ final class HttpClientException extends \RuntimeException
         if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
             $this->responseBody['message'] = $body;
         } elseif ($body) {
-            $this->responseBody = json_decode($body, true);
+            $this->responseBody = json_decode($body, true) ?? [];
         }
     }
 

--- a/src/CaptureHigherEd/LaravelJira/Exception/HttpClientException.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/HttpClientException.php
@@ -6,8 +6,9 @@ use Psr\Http\Message\ResponseInterface;
 
 final class HttpClientException extends \RuntimeException
 {
-    private ResponseInterface|null $response;
+    private ?ResponseInterface $response;
 
+    /** @var array<string, mixed> */
     private array $responseBody = [];
 
     private int $responseCode;
@@ -22,7 +23,7 @@ final class HttpClientException extends \RuntimeException
         $response->getBody()->rewind();
         $body = $response->getBody()->__toString();
 
-        if (0 !== strpos($response->getHeaderLine('Content-Type'), 'application/json')) {
+        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
             $this->responseBody['message'] = $body;
         } elseif ($body) {
             $this->responseBody = json_decode($body, true);
@@ -33,7 +34,7 @@ final class HttpClientException extends \RuntimeException
     {
         $body = $response->getBody()->__toString();
 
-        if (0 !== strpos($response->getHeaderLine('Content-Type'), 'application/json')) {
+        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
             $validationMessage = $body;
         } else {
             $jsonDecoded = json_decode($body, true);
@@ -85,7 +86,7 @@ final class HttpClientException extends \RuntimeException
     {
         $body = $response->getBody()->__toString();
 
-        if (0 !== strpos($response->getHeaderLine('Content-Type'), 'application/json')) {
+        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
             $validationMessage = $body;
         } else {
             $jsonDecoded = json_decode($body, true);
@@ -112,7 +113,7 @@ final class HttpClientException extends \RuntimeException
     {
         $body = $response->getBody()->__toString();
 
-        if (0 !== strpos($response->getHeaderLine('Content-Type'), 'application/json')) {
+        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
             $validationMessage = $body;
         } else {
             $jsonDecoded = json_decode($body, true);
@@ -126,7 +127,7 @@ final class HttpClientException extends \RuntimeException
 
     public static function unknown(ResponseInterface $response): self
     {
-        $message = "Unknown Error";
+        $message = 'Unknown Error';
 
         return new self($message, $response->getStatusCode(), $response);
     }
@@ -136,6 +137,9 @@ final class HttpClientException extends \RuntimeException
         return $this->response;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getResponseBody(): array
     {
         return $this->responseBody;

--- a/src/CaptureHigherEd/LaravelJira/Exception/HttpClientException.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/HttpClientException.php
@@ -19,6 +19,7 @@ final class HttpClientException extends \RuntimeException
         $this->response = $response;
         $this->responseCode = $response->getStatusCode();
 
+        $response->getBody()->rewind();
         $body = $response->getBody()->__toString();
 
         if (0 !== strpos($response->getHeaderLine('Content-Type'), 'application/json')) {
@@ -28,7 +29,7 @@ final class HttpClientException extends \RuntimeException
         }
     }
 
-    public static function badRequest(ResponseInterface $response)
+    public static function badRequest(ResponseInterface $response): self
     {
         $body = $response->getBody()->__toString();
 
@@ -44,38 +45,70 @@ final class HttpClientException extends \RuntimeException
         return new self($message, 400, $response);
     }
 
-    public static function unauthorized(ResponseInterface $response)
+    public static function unauthorized(ResponseInterface $response): self
     {
         return new self('Your credentials are incorrect.', 401, $response);
     }
 
-    public static function requestFailed(ResponseInterface $response)
+    public static function requestFailed(ResponseInterface $response): self
     {
         return new self('Parameters were valid but request failed. Try again.', 402, $response);
     }
 
-    public static function notFound(ResponseInterface $response)
+    public static function notFound(ResponseInterface $response): self
     {
         return new self('The endpoint you have tried to access does not exist.', 404, $response);
     }
 
-    public static function conflict(ResponseInterface $response)
+    public static function conflict(ResponseInterface $response): self
     {
 
         return new self('Request conflicts with current state of the target resource.', 409, $response);
     }
 
-    public static function payloadTooLarge(ResponseInterface $response)
+    public static function payloadTooLarge(ResponseInterface $response): self
     {
         return new self('Payload too large, your total attachment size is too big.', 413, $response);
     }
 
-    public static function tooManyRequests(ResponseInterface $response)
+    public static function tooManyRequests(ResponseInterface $response): self
     {
-        return new self('Too many requests.', 429, $response);
+        $retryAfter = $response->getHeaderLine('Retry-After');
+        $message = $retryAfter
+            ? "Too many requests. Retry after {$retryAfter} seconds."
+            : 'Too many requests.';
+
+        return new self($message, 429, $response);
     }
 
-    public static function forbidden(ResponseInterface $response)
+    public static function unprocessableEntity(ResponseInterface $response): self
+    {
+        $body = $response->getBody()->__toString();
+
+        if (0 !== strpos($response->getHeaderLine('Content-Type'), 'application/json')) {
+            $validationMessage = $body;
+        } else {
+            $jsonDecoded = json_decode($body, true);
+            $validationMessage = isset($jsonDecoded['errorMessages']) ? implode(', ', $jsonDecoded['errorMessages']) : $body;
+        }
+
+        $message = sprintf("Unprocessable entity. Jira validation failed.\n\n%s", $validationMessage);
+
+        return new self($message, 422, $response);
+    }
+
+    public static function serverError(ResponseInterface $response): self
+    {
+        $statusCode = $response->getStatusCode();
+
+        return new self(
+            sprintf('Jira server error (HTTP %d). Please try again later.', $statusCode),
+            $statusCode,
+            $response
+        );
+    }
+
+    public static function forbidden(ResponseInterface $response): self
     {
         $body = $response->getBody()->__toString();
 
@@ -91,7 +124,7 @@ final class HttpClientException extends \RuntimeException
         return new self($message, 403, $response);
     }
 
-    public static function unknown(ResponseInterface $response)
+    public static function unknown(ResponseInterface $response): self
     {
         $message = "Unknown Error";
 

--- a/src/CaptureHigherEd/LaravelJira/HttpClientConnector.php
+++ b/src/CaptureHigherEd/LaravelJira/HttpClientConnector.php
@@ -6,12 +6,11 @@ use GuzzleHttp\Client;
 
 class HttpClientConnector
 {
-    protected string|null $endpoint;
-    protected string|null $apiKey;
+    protected ?string $endpoint;
 
-    public function __construct()
-    {
-    }
+    protected ?string $apiKey;
+
+    public function __construct() {}
 
     public function setEndpoint(string $endpoint): self
     {
@@ -33,10 +32,10 @@ class HttpClientConnector
             'http_errors' => false,
             'base_uri' => $this->endpoint,
             'headers' => [
-                "Accept" => "application/json",
-                "Content-Type" => "application/json",
-                "Authorization" => "Basic {$this->apiKey}",
-            ]
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'Authorization' => "Basic {$this->apiKey}",
+            ],
         ]);
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Jira.php
+++ b/src/CaptureHigherEd/LaravelJira/Jira.php
@@ -21,7 +21,7 @@ class Jira
      * @param  string $endpoint - full path to the jira API
      * @return self
      */
-    public static function create(string $apiKey, string $endpoint = null): self
+    public static function create(string $apiKey, ?string $endpoint = null): self
     {
         $endpoint ??= config('jira.domain') . '/rest/api/3/';
         $httpClient = (new HttpClientConnector())

--- a/src/CaptureHigherEd/LaravelJira/Jira.php
+++ b/src/CaptureHigherEd/LaravelJira/Jira.php
@@ -2,12 +2,10 @@
 
 namespace CaptureHigherEd\LaravelJira;
 
-use Psr\Http\Client\ClientInterface;
-use CaptureHigherEd\LaravelJira\HttpClientConnector;
+use GuzzleHttp\ClientInterface;
 
 class Jira
 {
-
     private ClientInterface $httpClient;
 
     public function __construct(
@@ -17,39 +15,29 @@ class Jira
     }
 
     /**
-     * @param  string $apiKey - in the format base64_encode('someone@gmail.com:token1234')
-     * @param  string $endpoint - full path to the jira API
-     * @return self
+     * @param  string  $apiKey  - in the format base64_encode('someone@gmail.com:token1234')
+     * @param  string  $endpoint  - full path to the jira API
      */
     public static function create(string $apiKey, ?string $endpoint = null): self
     {
-        $endpoint ??= config('jira.domain') . '/rest/api/3/';
-        $httpClient = (new HttpClientConnector())
+        $endpoint ??= config('jira.domain').'/rest/api/3/';
+        $httpClient = (new HttpClientConnector)
             ->setApiKey($apiKey)
             ->setEndpoint($endpoint);
 
         return new self($httpClient);
     }
 
-    /**
-     * @return Api\Issues
-     */
     public function issues(): Api\Issues
     {
         return new Api\Issues($this->httpClient);
     }
 
-    /**
-     * @return Api\Fields
-     */
     public function fields(): Api\Fields
     {
         return new Api\Fields($this->httpClient);
     }
 
-    /**
-     * @return Api\Users
-     */
     public function users(): Api\Users
     {
         return new Api\Users($this->httpClient);

--- a/src/CaptureHigherEd/LaravelJira/Models/ApiResponse.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/ApiResponse.php
@@ -4,7 +4,7 @@ namespace CaptureHigherEd\LaravelJira\Models;
 
 interface ApiResponse
 {
-    public static function make(array $data): self;
+    public static function make(array $data = []): self;
 
     public function toArray(): array;
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/ApiResponse.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/ApiResponse.php
@@ -4,7 +4,13 @@ namespace CaptureHigherEd\LaravelJira\Models;
 
 interface ApiResponse
 {
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data = []): self;
 
+    /**
+     * @return array<mixed>
+     */
     public function toArray(): array;
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Attachment.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Attachment.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Attachment implements ApiResponse
+{
+    const ID = 'id';
+
+    const FILENAME = 'filename';
+
+    const MIME_TYPE = 'mimeType';
+
+    const SIZE = 'size';
+
+    const CONTENT = 'content';
+
+    const SELF = 'self';
+
+    private string $id = '';
+
+    private string $filename = '';
+
+    private string $mimeType = '';
+
+    private int $size = 0;
+
+    private string $content = '';
+
+    private string $self = '';
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->setId($data[self::ID] ?? '');
+        $model->setFilename($data[self::FILENAME] ?? '');
+        $model->setMimeType($data[self::MIME_TYPE] ?? '');
+        $model->setSize((int) ($data[self::SIZE] ?? 0));
+        $model->setContent($data[self::CONTENT] ?? '');
+        $model->setSelf($data[self::SELF] ?? '');
+
+        return $model;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    public function getMimeType(): string
+    {
+        return $this->mimeType;
+    }
+
+    public function getSize(): int
+    {
+        return $this->size;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    public function setId(string $value): self
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    public function setFilename(string $value): self
+    {
+        $this->filename = $value;
+
+        return $this;
+    }
+
+    public function setMimeType(string $value): self
+    {
+        $this->mimeType = $value;
+
+        return $this;
+    }
+
+    public function setSize(int $value): self
+    {
+        $this->size = $value;
+
+        return $this;
+    }
+
+    public function setContent(string $value): self
+    {
+        $this->content = $value;
+
+        return $this;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            self::ID => $this->id,
+            self::FILENAME => $this->filename,
+            self::MIME_TYPE => $this->mimeType,
+            self::SIZE => $this->size,
+            self::CONTENT => $this->content,
+            self::SELF => $this->self,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Attachment.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Attachment.php
@@ -16,6 +16,12 @@ final class Attachment implements ApiResponse
 
     const SELF = 'self';
 
+    const AUTHOR = 'author';
+
+    const CREATED = 'created';
+
+    const THUMBNAIL = 'thumbnail';
+
     private string $id = '';
 
     private string $filename = '';
@@ -27,6 +33,12 @@ final class Attachment implements ApiResponse
     private string $content = '';
 
     private string $self = '';
+
+    private ?User $author = null;
+
+    private string $created = '';
+
+    private string $thumbnail = '';
 
     private function __construct() {}
 
@@ -43,6 +55,9 @@ final class Attachment implements ApiResponse
         $model->setSize((int) ($data[self::SIZE] ?? 0));
         $model->setContent($data[self::CONTENT] ?? '');
         $model->setSelf($data[self::SELF] ?? '');
+        $model->setAuthor(isset($data[self::AUTHOR]) ? User::make($data[self::AUTHOR]) : null);
+        $model->setCreated($data[self::CREATED] ?? '');
+        $model->setThumbnail($data[self::THUMBNAIL] ?? '');
 
         return $model;
     }
@@ -75,6 +90,21 @@ final class Attachment implements ApiResponse
     public function getSelf(): string
     {
         return $this->self;
+    }
+
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function getCreated(): string
+    {
+        return $this->created;
+    }
+
+    public function getThumbnail(): string
+    {
+        return $this->thumbnail;
     }
 
     public function setId(string $value): self
@@ -119,6 +149,27 @@ final class Attachment implements ApiResponse
         return $this;
     }
 
+    public function setAuthor(?User $value): self
+    {
+        $this->author = $value;
+
+        return $this;
+    }
+
+    public function setCreated(string $value): self
+    {
+        $this->created = $value;
+
+        return $this;
+    }
+
+    public function setThumbnail(string $value): self
+    {
+        $this->thumbnail = $value;
+
+        return $this;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -131,6 +182,9 @@ final class Attachment implements ApiResponse
             self::SIZE => $this->size,
             self::CONTENT => $this->content,
             self::SELF => $this->self,
+            self::AUTHOR => $this->author?->toArray(),
+            self::CREATED => $this->created,
+            self::THUMBNAIL => $this->thumbnail,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Attachments.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Attachments.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Attachments implements ApiResponse
+{
+    /** @var array<int, Attachment> */
+    private array $attachments = [];
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $attachments = [];
+
+        foreach ($data as $item) {
+            $attachments[] = Attachment::make($item);
+        }
+
+        $model = new self;
+
+        $model->attachments = $attachments;
+
+        return $model;
+    }
+
+    /**
+     * @return array<int, Attachment>
+     */
+    public function getAttachments(): array
+    {
+        return $this->attachments;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        return array_map(fn (Attachment $a) => $a->toArray(), $this->attachments);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Comment.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Comment.php
@@ -14,6 +14,14 @@ final class Comment implements ApiResponse
 
     const SELF = 'self';
 
+    const AUTHOR = 'author';
+
+    const UPDATE_AUTHOR = 'updateAuthor';
+
+    const JSD_PUBLIC = 'jsdPublic';
+
+    const VISIBILITY = 'visibility';
+
     private string $id = '';
 
     /** @var array<mixed> */
@@ -24,6 +32,15 @@ final class Comment implements ApiResponse
     private string $updated = '';
 
     private string $self = '';
+
+    private ?User $author = null;
+
+    private ?User $updateAuthor = null;
+
+    private bool $jsdPublic = true;
+
+    /** @var array<string, mixed> */
+    private array $visibility = [];
 
     private function __construct() {}
 
@@ -39,6 +56,10 @@ final class Comment implements ApiResponse
         $model->setCreated($data[self::CREATED] ?? '');
         $model->setUpdated($data[self::UPDATED] ?? '');
         $model->setSelf($data[self::SELF] ?? '');
+        $model->setAuthor(isset($data[self::AUTHOR]) ? User::make($data[self::AUTHOR]) : null);
+        $model->setUpdateAuthor(isset($data[self::UPDATE_AUTHOR]) ? User::make($data[self::UPDATE_AUTHOR]) : null);
+        $model->setJsdPublic($data[self::JSD_PUBLIC] ?? true);
+        $model->setVisibility($data[self::VISIBILITY] ?? []);
 
         return $model;
     }
@@ -69,6 +90,29 @@ final class Comment implements ApiResponse
     public function getSelf(): string
     {
         return $this->self;
+    }
+
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function getUpdateAuthor(): ?User
+    {
+        return $this->updateAuthor;
+    }
+
+    public function getJsdPublic(): bool
+    {
+        return $this->jsdPublic;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getVisibility(): array
+    {
+        return $this->visibility;
     }
 
     public function setId(string $value): self
@@ -109,6 +153,37 @@ final class Comment implements ApiResponse
         return $this;
     }
 
+    public function setAuthor(?User $value): self
+    {
+        $this->author = $value;
+
+        return $this;
+    }
+
+    public function setUpdateAuthor(?User $value): self
+    {
+        $this->updateAuthor = $value;
+
+        return $this;
+    }
+
+    public function setJsdPublic(bool $value): self
+    {
+        $this->jsdPublic = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public function setVisibility(array $value): self
+    {
+        $this->visibility = $value;
+
+        return $this;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -120,6 +195,10 @@ final class Comment implements ApiResponse
             self::CREATED => $this->created,
             self::UPDATED => $this->updated,
             self::SELF => $this->self,
+            self::AUTHOR => $this->author?->toArray(),
+            self::UPDATE_AUTHOR => $this->updateAuthor?->toArray(),
+            self::JSD_PUBLIC => $this->jsdPublic,
+            self::VISIBILITY => $this->visibility,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Comment.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Comment.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Comment implements ApiResponse
+{
+    const ID = 'id';
+
+    const BODY = 'body';
+
+    const CREATED = 'created';
+
+    const UPDATED = 'updated';
+
+    const SELF = 'self';
+
+    private string $id = '';
+
+    /** @var array<mixed> */
+    private array $body = [];
+
+    private string $created = '';
+
+    private string $updated = '';
+
+    private string $self = '';
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->setId($data[self::ID] ?? '');
+        $model->setBody($data[self::BODY] ?? []);
+        $model->setCreated($data[self::CREATED] ?? '');
+        $model->setUpdated($data[self::UPDATED] ?? '');
+        $model->setSelf($data[self::SELF] ?? '');
+
+        return $model;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getBody(): array
+    {
+        return $this->body;
+    }
+
+    public function getCreated(): string
+    {
+        return $this->created;
+    }
+
+    public function getUpdated(): string
+    {
+        return $this->updated;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    public function setId(string $value): self
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     */
+    public function setBody(array $value): self
+    {
+        $this->body = $value;
+
+        return $this;
+    }
+
+    public function setCreated(string $value): self
+    {
+        $this->created = $value;
+
+        return $this;
+    }
+
+    public function setUpdated(string $value): self
+    {
+        $this->updated = $value;
+
+        return $this;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            self::ID => $this->id,
+            self::BODY => $this->body,
+            self::CREATED => $this->created,
+            self::UPDATED => $this->updated,
+            self::SELF => $this->self,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Field.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Field.php
@@ -2,8 +2,6 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-use CaptureHigherEd\LaravelJira\Jira;
-
 final class Field implements ApiResponse
 {
     const CLAUSENAMES = 'clauseNames';
@@ -30,7 +28,7 @@ final class Field implements ApiResponse
     {
     }
 
-    public static function make(?array $data = []): self
+    public static function make(array $data = []): self
     {
         $model = new self();
 
@@ -57,78 +55,56 @@ final class Field implements ApiResponse
         return $this->key;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getCustom()
+    public function getCustom(): bool
     {
         return $this->custom;
     }
 
-    public function getSearchable()
+    public function getSearchable(): bool
     {
         return $this->searchable;
     }
 
-    public function getNavigable()
+    public function getNavigable(): bool
     {
         return $this->navigable;
     }
 
-    public function getOrderable()
+    public function getOrderable(): bool
     {
         return $this->orderable;
     }
 
-    public function getSchema()
+    public function getSchema(): array
     {
         return $this->schema;
     }
 
-    public function getClauseNames()
+    public function getClauseNames(): array
     {
         return $this->clauseNames;
     }
 
-    public function getOptions(string $project_key, string $issue_type_name)
-    {
-        $jira = app(Jira::class);
-        $meta = $jira->issues()->getCreateMeta(['expand' => 'projects.issuetypes.fields']);
-
-        foreach ($meta['projects'] as $project) {
-            if ($project['key'] == $project_key) {
-                foreach ($project['issuetypes'] as $issue_type) {
-                    if ($issue_type['name'] == $issue_type_name) {
-                        foreach ($issue_type['fields'] as $field_key => $field) {
-                            if ($field_key == $this->getKey()) {
-                                return collect($field['allowedValues'])->pluck('value', 'value')->toArray();
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return [];
-    }
-
-    public function setId($value): self
+    public function setId(string $value): self
     {
         $this->id = $value;
 
         return $this;
     }
 
-    public function setKey($value): self
+    public function setKey(string $value): self
     {
         $this->key = $value;
 
         return $this;
     }
 
-    public function setName($value): self
+    public function setName(string $value): self
     {
         $this->name = $value;
 
@@ -179,6 +155,16 @@ final class Field implements ApiResponse
 
     public function toArray(): array
     {
-        return [];
+        return [
+            self::ID          => $this->id,
+            self::KEY         => $this->key,
+            self::NAME        => $this->name,
+            self::CUSTOM      => $this->custom,
+            self::ORDERABLE   => $this->orderable,
+            self::NAVIGABLE   => $this->navigable,
+            self::SEARCHABLE  => $this->searchable,
+            self::CLAUSENAMES => $this->clauseNames,
+            self::SCHEMA      => $this->schema,
+        ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Field.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Field.php
@@ -5,32 +5,51 @@ namespace CaptureHigherEd\LaravelJira\Models;
 final class Field implements ApiResponse
 {
     const CLAUSENAMES = 'clauseNames';
+
     const SEARCHABLE = 'searchable';
+
     const NAVIGABLE = 'navigable';
+
     const ORDERABLE = 'orderable';
+
     const SCHEMA = 'schema';
+
     const CUSTOM = 'custom';
+
     const NAME = 'name';
+
     const KEY = 'key';
+
     const ID = 'id';
 
     private string $key = '';
+
     private string $id = '';
+
     private string $name = '';
+
     private bool $custom = false;
+
     private bool $orderable = false;
+
     private bool $navigable = false;
+
     private bool $searchable = false;
+
+    /** @var array<string> */
     private array $clauseNames = [];
+
+    /** @var array<string, mixed> */
     private array $schema = [];
 
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data = []): self
     {
-        $model = new self();
+        $model = new self;
 
         $model->setId($data[self::ID] ?? '');
         $model->setKey($data[self::KEY] ?? '');
@@ -80,11 +99,17 @@ final class Field implements ApiResponse
         return $this->orderable;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getSchema(): array
     {
         return $this->schema;
     }
 
+    /**
+     * @return array<string>
+     */
     public function getClauseNames(): array
     {
         return $this->clauseNames;
@@ -139,6 +164,9 @@ final class Field implements ApiResponse
         return $this;
     }
 
+    /**
+     * @param  array<string, mixed>  $value
+     */
     public function setSchema(array $value): self
     {
         $this->schema = $value;
@@ -146,6 +174,9 @@ final class Field implements ApiResponse
         return $this;
     }
 
+    /**
+     * @param  array<string>  $value
+     */
     public function setClauseNames(array $value): self
     {
         $this->clauseNames = $value;
@@ -153,18 +184,21 @@ final class Field implements ApiResponse
         return $this;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [
-            self::ID          => $this->id,
-            self::KEY         => $this->key,
-            self::NAME        => $this->name,
-            self::CUSTOM      => $this->custom,
-            self::ORDERABLE   => $this->orderable,
-            self::NAVIGABLE   => $this->navigable,
-            self::SEARCHABLE  => $this->searchable,
+            self::ID => $this->id,
+            self::KEY => $this->key,
+            self::NAME => $this->name,
+            self::CUSTOM => $this->custom,
+            self::ORDERABLE => $this->orderable,
+            self::NAVIGABLE => $this->navigable,
+            self::SEARCHABLE => $this->searchable,
             self::CLAUSENAMES => $this->clauseNames,
-            self::SCHEMA      => $this->schema,
+            self::SCHEMA => $this->schema,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Field.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Field.php
@@ -14,6 +14,8 @@ final class Field implements ApiResponse
 
     const SCHEMA = 'schema';
 
+    const SCOPE = 'scope';
+
     const CUSTOM = 'custom';
 
     const NAME = 'name';
@@ -42,6 +44,9 @@ final class Field implements ApiResponse
     /** @var array<string, mixed> */
     private array $schema = [];
 
+    /** @var array<string, mixed> */
+    private array $scope = [];
+
     private function __construct() {}
 
     /**
@@ -60,6 +65,7 @@ final class Field implements ApiResponse
         $model->setNavigable($data[self::NAVIGABLE] ?? false);
         $model->setSchema($data[self::SCHEMA] ?? []);
         $model->setClauseNames($data[self::CLAUSENAMES] ?? []);
+        $model->setScope($data[self::SCOPE] ?? []);
 
         return $model;
     }
@@ -113,6 +119,14 @@ final class Field implements ApiResponse
     public function getClauseNames(): array
     {
         return $this->clauseNames;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getScope(): array
+    {
+        return $this->scope;
     }
 
     public function setId(string $value): self
@@ -185,6 +199,16 @@ final class Field implements ApiResponse
     }
 
     /**
+     * @param  array<string, mixed>  $value
+     */
+    public function setScope(array $value): self
+    {
+        $this->scope = $value;
+
+        return $this;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toArray(): array
@@ -199,6 +223,7 @@ final class Field implements ApiResponse
             self::SEARCHABLE => $this->searchable,
             self::CLAUSENAMES => $this->clauseNames,
             self::SCHEMA => $this->schema,
+            self::SCOPE => $this->scope,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/FieldMeta.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/FieldMeta.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class FieldMeta implements ApiResponse
+{
+    const FIELD_ID = 'fieldId';
+
+    const NAME = 'name';
+
+    const REQUIRED = 'required';
+
+    const SCHEMA = 'schema';
+
+    const OPERATIONS = 'operations';
+
+    const ALLOWED_VALUES = 'allowedValues';
+
+    private string $fieldId = '';
+
+    private string $name = '';
+
+    private bool $required = false;
+
+    /** @var array<string, mixed> */
+    private array $schema = [];
+
+    /** @var array<string> */
+    private array $operations = [];
+
+    /** @var array<mixed> */
+    private array $allowedValues = [];
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->setFieldId($data[self::FIELD_ID] ?? '');
+        $model->setName($data[self::NAME] ?? '');
+        $model->setRequired($data[self::REQUIRED] ?? false);
+        $model->setSchema($data[self::SCHEMA] ?? []);
+        $model->setOperations($data[self::OPERATIONS] ?? []);
+        $model->setAllowedValues($data[self::ALLOWED_VALUES] ?? []);
+
+        return $model;
+    }
+
+    public function getFieldId(): string
+    {
+        return $this->fieldId;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getRequired(): bool
+    {
+        return $this->required;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSchema(): array
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getAllowedValues(): array
+    {
+        return $this->allowedValues;
+    }
+
+    public function setFieldId(string $value): self
+    {
+        $this->fieldId = $value;
+
+        return $this;
+    }
+
+    public function setName(string $value): self
+    {
+        $this->name = $value;
+
+        return $this;
+    }
+
+    public function setRequired(bool $value): self
+    {
+        $this->required = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public function setSchema(array $value): self
+    {
+        $this->schema = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string>  $value
+     */
+    public function setOperations(array $value): self
+    {
+        $this->operations = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     */
+    public function setAllowedValues(array $value): self
+    {
+        $this->allowedValues = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            self::FIELD_ID => $this->fieldId,
+            self::NAME => $this->name,
+            self::REQUIRED => $this->required,
+            self::SCHEMA => $this->schema,
+            self::OPERATIONS => $this->operations,
+            self::ALLOWED_VALUES => $this->allowedValues,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/FieldMetas.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/FieldMetas.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class FieldMetas implements ApiResponse
+{
+    const FIELDS = 'fields';
+
+    /** @var array<int, FieldMeta> */
+    private array $fields = [];
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $fields = [];
+
+        if (isset($data[self::FIELDS])) {
+            foreach ($data[self::FIELDS] as $item) {
+                $fields[] = FieldMeta::make($item);
+            }
+        }
+
+        $model = new self;
+
+        $model->fields = $fields;
+
+        return $model;
+    }
+
+    /**
+     * @return array<int, FieldMeta>
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        return array_map(fn (FieldMeta $field) => $field->toArray(), $this->fields);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Fields.php
@@ -12,7 +12,7 @@ final class Fields implements ApiResponse
     {
     }
 
-    public static function make(?array $data = []): self
+    public static function make(array $data = []): self
     {
         $fields = [];
 
@@ -27,12 +27,12 @@ final class Fields implements ApiResponse
         return $model;
     }
 
-    public function getFields()
+    public function getFields(): array
     {
         return $this->fields;
     }
 
-    public function getCustomFields()
+    public function getCustomFields(): array
     {
         return array_filter($this->fields, static function (Field $field): bool {
             return str_starts_with($field->getKey(), 'customfield_');
@@ -42,11 +42,11 @@ final class Fields implements ApiResponse
     public function getCustomFieldId(string $name): string
     {
         $field = current(array_filter($this->getCustomFields(), static function (Field $field) use ($name): bool {
-            return $field->getName() == $name;
+            return $field->getName() === $name;
         }));
 
         if (!$field) {
-            throw new CustomFieldDoesNotExistException();
+            throw new CustomFieldDoesNotExistException($name);
         }
 
         return $field->getId();
@@ -55,11 +55,11 @@ final class Fields implements ApiResponse
     public function getCustomField(string $name): Field
     {
         $field = current(array_filter($this->getCustomFields(), static function (Field $field) use ($name): bool {
-            return $field->getName() == $name;
+            return $field->getName() === $name;
         }));
 
         if (!$field) {
-            throw new CustomFieldDoesNotExistException();
+            throw new CustomFieldDoesNotExistException($name);
         }
 
         return $field;
@@ -67,6 +67,6 @@ final class Fields implements ApiResponse
 
     public function toArray(): array
     {
-        return [];
+        return array_map(fn (Field $field) => $field->toArray(), $this->fields);
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Fields.php
@@ -6,12 +6,14 @@ use CaptureHigherEd\LaravelJira\Exception\CustomFieldDoesNotExistException;
 
 final class Fields implements ApiResponse
 {
+    /** @var array<int, Field> */
     private array $fields = [];
 
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data = []): self
     {
         $fields = [];
@@ -20,18 +22,24 @@ final class Fields implements ApiResponse
             $fields[] = Field::make($item);
         }
 
-        $model = new self();
+        $model = new self;
 
         $model->fields = $fields;
 
         return $model;
     }
 
+    /**
+     * @return array<int, Field>
+     */
     public function getFields(): array
     {
         return $this->fields;
     }
 
+    /**
+     * @return array<int, Field>
+     */
     public function getCustomFields(): array
     {
         return array_filter($this->fields, static function (Field $field): bool {
@@ -45,7 +53,7 @@ final class Fields implements ApiResponse
             return $field->getName() === $name;
         }));
 
-        if (!$field) {
+        if (! $field) {
             throw new CustomFieldDoesNotExistException($name);
         }
 
@@ -58,13 +66,16 @@ final class Fields implements ApiResponse
             return $field->getName() === $name;
         }));
 
-        if (!$field) {
+        if (! $field) {
             throw new CustomFieldDoesNotExistException($name);
         }
 
         return $field;
     }
 
+    /**
+     * @return array<int, array<string, mixed>>
+     */
     public function toArray(): array
     {
         return array_map(fn (Field $field) => $field->toArray(), $this->fields);

--- a/src/CaptureHigherEd/LaravelJira/Models/Issue.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Issue.php
@@ -22,13 +22,13 @@ final class Issue implements ApiResponse
     {
     }
 
-    public static function make(?array $data = []): self
+    public static function make(array $data = []): self
     {
         $model = new self();
 
         $model->setId($data[self::ID] ?? '');
         $model->setKey($data[self::KEY] ?? '');
-        $model->setFields(array_filter($data[self::FIELDS] ?? []));
+        $model->setFields(array_filter($data[self::FIELDS] ?? [], fn ($v) => $v !== null));
 
         return $model;
     }
@@ -63,86 +63,86 @@ final class Issue implements ApiResponse
         return config('jira.domain') . '/browse/' . $this->key;
     }
 
-    public function setFields($value): self
+    public function setFields(array $value): self
     {
         $this->fields = $value;
 
         return $this;
     }
 
-    public function setField($field, $value): self
+    public function setField(string $field, mixed $value): self
     {
         $this->fields[$field] = $value;
 
         return $this;
     }
 
-    public function setId($value): self
+    public function setId(string $value): self
     {
         $this->id = $value;
 
         return $this;
     }
 
-    public function setKey($value): self
+    public function setKey(string $value): self
     {
         $this->key = $value;
 
         return $this;
     }
 
-    public function setProjectByKey($project): self
+    public function setProjectByKey(string $project): self
     {
         return $this->setField(self::PROJECT, ['key' => $project]);
     }
 
-    public function setSummary($value): self
+    public function setSummary(string $value): self
     {
         return $this->setField(self::SUMMARY, $value);
     }
 
-    public function setDescription($value): self
+    public function setDescription(mixed $value): self
     {
         return $this->setCustomFieldByContent(self::DESCRIPTION, $value);
     }
 
-    public function setIssueType($value): self
+    public function setIssueType(mixed $value): self
     {
         return $this->setField(self::ISSUETYPE, $value);
     }
 
-    public function setDueDate($value): self
+    public function setDueDate(string $value): self
     {
         return $this->setField(self::DUEDATE, $value);
     }
 
-    public function setReporter($value): self
+    public function setReporter(string $value): self
     {
         return $this->setCustomFieldById(self::REPORTER, $value);
     }
 
-    public function setIssueTypeByName($value): self
+    public function setIssueTypeByName(string $value): self
     {
         return $this->setIssueType(["name" => $value]);
     }
 
-    public function setCustomField($field, $value): self
+    public function setCustomField(string $field, mixed $value): self
     {
         return $this->setField($field, $value);
     }
 
-    public function setCustomFieldById($field, $value): self
+    public function setCustomFieldById(string $field, string $value): self
     {
         return $this->setCustomField($field, ["id" => $value]);
     }
 
-    public function setCustomFieldByValue($field, $value, ?bool $is_multi_select = true): self
+    public function setCustomFieldByValue(string $field, mixed $value, ?bool $is_multi_select = true): self
     {
         $value_array = $is_multi_select ? [["value" => $value]] : ["value" => $value];
         return $this->setCustomField($field, $value_array);
     }
 
-    public function setCustomFieldByContent($field, $value): self
+    public function setCustomFieldByContent(string $field, mixed $value): self
     {
         return $this->setField($field, [
             "content" => $value,

--- a/src/CaptureHigherEd/LaravelJira/Models/Issue.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Issue.php
@@ -5,26 +5,38 @@ namespace CaptureHigherEd\LaravelJira\Models;
 final class Issue implements ApiResponse
 {
     const KEY = 'key';
+
     const ID = 'id';
+
     const FIELDS = 'fields';
+
     const SUMMARY = 'summary';
+
     const PROJECT = 'project';
+
     const DESCRIPTION = 'description';
+
     const ISSUETYPE = 'issuetype';
+
     const DUEDATE = 'duedate';
+
     const REPORTER = 'reporter';
 
+    /** @var array<string, mixed> */
     private array $fields = [];
+
     private string $key = '';
+
     private string $id = '';
 
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data = []): self
     {
-        $model = new self();
+        $model = new self;
 
         $model->setId($data[self::ID] ?? '');
         $model->setKey($data[self::KEY] ?? '');
@@ -33,17 +45,23 @@ final class Issue implements ApiResponse
         return $model;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getFields(): array
     {
         return $this->fields;
     }
 
-    public function getSummary(): string|null
+    public function getSummary(): ?string
     {
         return $this->fields[self::SUMMARY] ?? null;
     }
 
-    public function getDescription(): array|null
+    /**
+     * @return array<mixed>|null
+     */
+    public function getDescription(): ?array
     {
         return $this->fields[self::DESCRIPTION] ?? null;
     }
@@ -60,9 +78,12 @@ final class Issue implements ApiResponse
 
     public function getLink(): string
     {
-        return config('jira.domain') . '/browse/' . $this->key;
+        return config('jira.domain').'/browse/'.$this->key;
     }
 
+    /**
+     * @param  array<string, mixed>  $value
+     */
     public function setFields(array $value): self
     {
         $this->fields = $value;
@@ -123,7 +144,7 @@ final class Issue implements ApiResponse
 
     public function setIssueTypeByName(string $value): self
     {
-        return $this->setIssueType(["name" => $value]);
+        return $this->setIssueType(['name' => $value]);
     }
 
     public function setCustomField(string $field, mixed $value): self
@@ -133,24 +154,28 @@ final class Issue implements ApiResponse
 
     public function setCustomFieldById(string $field, string $value): self
     {
-        return $this->setCustomField($field, ["id" => $value]);
+        return $this->setCustomField($field, ['id' => $value]);
     }
 
     public function setCustomFieldByValue(string $field, mixed $value, ?bool $is_multi_select = true): self
     {
-        $value_array = $is_multi_select ? [["value" => $value]] : ["value" => $value];
+        $value_array = $is_multi_select ? [['value' => $value]] : ['value' => $value];
+
         return $this->setCustomField($field, $value_array);
     }
 
     public function setCustomFieldByContent(string $field, mixed $value): self
     {
         return $this->setField($field, [
-            "content" => $value,
-            "type" => "doc",
-            "version" => 1,
+            'content' => $value,
+            'type' => 'doc',
+            'version' => 1,
         ]);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [

--- a/src/CaptureHigherEd/LaravelJira/Models/Issue.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Issue.php
@@ -8,19 +8,37 @@ final class Issue implements ApiResponse
 
     const ID = 'id';
 
+    const SELF = 'self';
+
     const FIELDS = 'fields';
 
     const SUMMARY = 'summary';
 
-    const PROJECT = 'project';
-
     const DESCRIPTION = 'description';
+
+    const STATUS = 'status';
+
+    const ASSIGNEE = 'assignee';
+
+    const REPORTER = 'reporter';
+
+    const PRIORITY = 'priority';
 
     const ISSUETYPE = 'issuetype';
 
+    const PROJECT = 'project';
+
+    const LABELS = 'labels';
+
+    const CREATED = 'created';
+
+    const UPDATED = 'updated';
+
     const DUEDATE = 'duedate';
 
-    const REPORTER = 'reporter';
+    const RESOLUTION = 'resolution';
+
+    const RESOLUTIONDATE = 'resolutiondate';
 
     /** @var array<string, mixed> */
     private array $fields = [];
@@ -28,6 +46,8 @@ final class Issue implements ApiResponse
     private string $key = '';
 
     private string $id = '';
+
+    private string $self = '';
 
     private function __construct() {}
 
@@ -40,6 +60,7 @@ final class Issue implements ApiResponse
 
         $model->setId($data[self::ID] ?? '');
         $model->setKey($data[self::KEY] ?? '');
+        $model->setSelf($data[self::SELF] ?? '');
         $model->setFields(array_filter($data[self::FIELDS] ?? [], fn ($v) => $v !== null));
 
         return $model;
@@ -66,6 +87,83 @@ final class Issue implements ApiResponse
         return $this->fields[self::DESCRIPTION] ?? null;
     }
 
+    public function getStatus(): ?Status
+    {
+        $data = $this->fields[self::STATUS] ?? null;
+
+        return $data !== null ? Status::make($data) : null;
+    }
+
+    public function getAssignee(): ?User
+    {
+        $data = $this->fields[self::ASSIGNEE] ?? null;
+
+        return $data !== null ? User::make($data) : null;
+    }
+
+    public function getReporter(): ?User
+    {
+        $data = $this->fields[self::REPORTER] ?? null;
+
+        return $data !== null ? User::make($data) : null;
+    }
+
+    public function getPriority(): ?Priority
+    {
+        $data = $this->fields[self::PRIORITY] ?? null;
+
+        return $data !== null ? Priority::make($data) : null;
+    }
+
+    public function getIssueType(): ?IssueType
+    {
+        $data = $this->fields[self::ISSUETYPE] ?? null;
+
+        return $data !== null ? IssueType::make($data) : null;
+    }
+
+    public function getProject(): ?Project
+    {
+        $data = $this->fields[self::PROJECT] ?? null;
+
+        return $data !== null ? Project::make($data) : null;
+    }
+
+    /**
+     * @return array<string>|null
+     */
+    public function getLabels(): ?array
+    {
+        return $this->fields[self::LABELS] ?? null;
+    }
+
+    public function getCreated(): ?string
+    {
+        return $this->fields[self::CREATED] ?? null;
+    }
+
+    public function getUpdated(): ?string
+    {
+        return $this->fields[self::UPDATED] ?? null;
+    }
+
+    public function getDueDate(): ?string
+    {
+        return $this->fields[self::DUEDATE] ?? null;
+    }
+
+    public function getResolution(): ?Resolution
+    {
+        $data = $this->fields[self::RESOLUTION] ?? null;
+
+        return $data !== null ? Resolution::make($data) : null;
+    }
+
+    public function getResolutionDate(): ?string
+    {
+        return $this->fields[self::RESOLUTIONDATE] ?? null;
+    }
+
     public function getId(): string
     {
         return $this->id;
@@ -74,6 +172,11 @@ final class Issue implements ApiResponse
     public function getKey(): string
     {
         return $this->key;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
     }
 
     public function getLink(): string
@@ -108,6 +211,13 @@ final class Issue implements ApiResponse
     public function setKey(string $value): self
     {
         $this->key = $value;
+
+        return $this;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
 
         return $this;
     }

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueType.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueType.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class IssueType implements ApiResponse
+{
+    const ID = 'id';
+
+    const NAME = 'name';
+
+    const DESCRIPTION = 'description';
+
+    const SUBTASK = 'subtask';
+
+    const ICON_URL = 'iconUrl';
+
+    const SELF = 'self';
+
+    private string $id = '';
+
+    private string $name = '';
+
+    private string $description = '';
+
+    private bool $subtask = false;
+
+    private string $iconUrl = '';
+
+    private string $self = '';
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->setId($data[self::ID] ?? '');
+        $model->setName($data[self::NAME] ?? '');
+        $model->setDescription($data[self::DESCRIPTION] ?? '');
+        $model->setSubtask($data[self::SUBTASK] ?? false);
+        $model->setIconUrl($data[self::ICON_URL] ?? '');
+        $model->setSelf($data[self::SELF] ?? '');
+
+        return $model;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getSubtask(): bool
+    {
+        return $this->subtask;
+    }
+
+    public function getIconUrl(): string
+    {
+        return $this->iconUrl;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    public function setId(string $value): self
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    public function setName(string $value): self
+    {
+        $this->name = $value;
+
+        return $this;
+    }
+
+    public function setDescription(string $value): self
+    {
+        $this->description = $value;
+
+        return $this;
+    }
+
+    public function setSubtask(bool $value): self
+    {
+        $this->subtask = $value;
+
+        return $this;
+    }
+
+    public function setIconUrl(string $value): self
+    {
+        $this->iconUrl = $value;
+
+        return $this;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            self::ID => $this->id,
+            self::NAME => $this->name,
+            self::DESCRIPTION => $this->description,
+            self::SUBTASK => $this->subtask,
+            self::ICON_URL => $this->iconUrl,
+            self::SELF => $this->self,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueTypes.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueTypes.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class IssueTypes implements ApiResponse
+{
+    const ISSUE_TYPES = 'issueTypes';
+
+    /** @var array<int, IssueType> */
+    private array $issueTypes = [];
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $issueTypes = [];
+
+        if (isset($data[self::ISSUE_TYPES])) {
+            foreach ($data[self::ISSUE_TYPES] as $item) {
+                $issueTypes[] = IssueType::make($item);
+            }
+        }
+
+        $model = new self;
+
+        $model->issueTypes = $issueTypes;
+
+        return $model;
+    }
+
+    /**
+     * @return array<int, IssueType>
+     */
+    public function getIssueTypes(): array
+    {
+        return $this->issueTypes;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        return array_map(fn (IssueType $issueType) => $issueType->toArray(), $this->issueTypes);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Priority.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Priority.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Priority implements ApiResponse
+{
+    const ID = 'id';
+
+    const NAME = 'name';
+
+    const DESCRIPTION = 'description';
+
+    const ICON_URL = 'iconUrl';
+
+    const SELF = 'self';
+
+    const STATUS_COLOR = 'statusColor';
+
+    const IS_DEFAULT = 'isDefault';
+
+    const AVATAR_ID = 'avatarId';
+
+    private string $id = '';
+
+    private string $name = '';
+
+    private string $description = '';
+
+    private string $iconUrl = '';
+
+    private string $self = '';
+
+    private string $statusColor = '';
+
+    private bool $isDefault = false;
+
+    private int $avatarId = 0;
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->setId($data[self::ID] ?? '');
+        $model->setName($data[self::NAME] ?? '');
+        $model->setDescription($data[self::DESCRIPTION] ?? '');
+        $model->setIconUrl($data[self::ICON_URL] ?? '');
+        $model->setSelf($data[self::SELF] ?? '');
+        $model->setStatusColor($data[self::STATUS_COLOR] ?? '');
+        $model->setIsDefault($data[self::IS_DEFAULT] ?? false);
+        $model->setAvatarId((int) ($data[self::AVATAR_ID] ?? 0));
+
+        return $model;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getIconUrl(): string
+    {
+        return $this->iconUrl;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    public function getStatusColor(): string
+    {
+        return $this->statusColor;
+    }
+
+    public function getIsDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    public function getAvatarId(): int
+    {
+        return $this->avatarId;
+    }
+
+    public function setId(string $value): self
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    public function setName(string $value): self
+    {
+        $this->name = $value;
+
+        return $this;
+    }
+
+    public function setDescription(string $value): self
+    {
+        $this->description = $value;
+
+        return $this;
+    }
+
+    public function setIconUrl(string $value): self
+    {
+        $this->iconUrl = $value;
+
+        return $this;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    public function setStatusColor(string $value): self
+    {
+        $this->statusColor = $value;
+
+        return $this;
+    }
+
+    public function setIsDefault(bool $value): self
+    {
+        $this->isDefault = $value;
+
+        return $this;
+    }
+
+    public function setAvatarId(int $value): self
+    {
+        $this->avatarId = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            self::ID => $this->id,
+            self::NAME => $this->name,
+            self::DESCRIPTION => $this->description,
+            self::ICON_URL => $this->iconUrl,
+            self::SELF => $this->self,
+            self::STATUS_COLOR => $this->statusColor,
+            self::IS_DEFAULT => $this->isDefault,
+            self::AVATAR_ID => $this->avatarId,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Project.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Project.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Project implements ApiResponse
+{
+    const ID = 'id';
+
+    const KEY = 'key';
+
+    const NAME = 'name';
+
+    const SELF = 'self';
+
+    const PROJECT_TYPE_KEY = 'projectTypeKey';
+
+    const SIMPLIFIED = 'simplified';
+
+    const AVATAR_URLS = 'avatarUrls';
+
+    private string $id = '';
+
+    private string $key = '';
+
+    private string $name = '';
+
+    private string $self = '';
+
+    private string $projectTypeKey = '';
+
+    private bool $simplified = false;
+
+    /** @var array<string, string> */
+    private array $avatarUrls = [];
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->setId($data[self::ID] ?? '');
+        $model->setKey($data[self::KEY] ?? '');
+        $model->setName($data[self::NAME] ?? '');
+        $model->setSelf($data[self::SELF] ?? '');
+        $model->setProjectTypeKey($data[self::PROJECT_TYPE_KEY] ?? '');
+        $model->setSimplified($data[self::SIMPLIFIED] ?? false);
+        $model->setAvatarUrls($data[self::AVATAR_URLS] ?? []);
+
+        return $model;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    public function getProjectTypeKey(): string
+    {
+        return $this->projectTypeKey;
+    }
+
+    public function getSimplified(): bool
+    {
+        return $this->simplified;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAvatarUrls(): array
+    {
+        return $this->avatarUrls;
+    }
+
+    public function setId(string $value): self
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    public function setKey(string $value): self
+    {
+        $this->key = $value;
+
+        return $this;
+    }
+
+    public function setName(string $value): self
+    {
+        $this->name = $value;
+
+        return $this;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    public function setProjectTypeKey(string $value): self
+    {
+        $this->projectTypeKey = $value;
+
+        return $this;
+    }
+
+    public function setSimplified(bool $value): self
+    {
+        $this->simplified = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, string>  $value
+     */
+    public function setAvatarUrls(array $value): self
+    {
+        $this->avatarUrls = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            self::ID => $this->id,
+            self::KEY => $this->key,
+            self::NAME => $this->name,
+            self::SELF => $this->self,
+            self::PROJECT_TYPE_KEY => $this->projectTypeKey,
+            self::SIMPLIFIED => $this->simplified,
+            self::AVATAR_URLS => $this->avatarUrls,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Resolution.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Resolution.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Resolution implements ApiResponse
+{
+    const ID = 'id';
+
+    const NAME = 'name';
+
+    const DESCRIPTION = 'description';
+
+    const SELF = 'self';
+
+    private string $id = '';
+
+    private string $name = '';
+
+    private string $description = '';
+
+    private string $self = '';
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->setId($data[self::ID] ?? '');
+        $model->setName($data[self::NAME] ?? '');
+        $model->setDescription($data[self::DESCRIPTION] ?? '');
+        $model->setSelf($data[self::SELF] ?? '');
+
+        return $model;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    public function setId(string $value): self
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    public function setName(string $value): self
+    {
+        $this->name = $value;
+
+        return $this;
+    }
+
+    public function setDescription(string $value): self
+    {
+        $this->description = $value;
+
+        return $this;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            self::ID => $this->id,
+            self::NAME => $this->name,
+            self::DESCRIPTION => $this->description,
+            self::SELF => $this->self,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Search.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Search.php
@@ -4,18 +4,20 @@ namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Search implements ApiResponse
 {
+    const ISSUES = 'issues';
+
     private array $issues = [];
 
     private function __construct()
     {
     }
 
-    public static function make(?array $data = []): self
+    public static function make(array $data = []): self
     {
         $issues = [];
 
-        if (isset($data['issues'])) {
-            foreach ($data['issues'] as $item) {
+        if (isset($data[self::ISSUES])) {
+            foreach ($data[self::ISSUES] as $item) {
                 $issues[] = Issue::make($item);
             }
         }
@@ -27,13 +29,15 @@ final class Search implements ApiResponse
         return $model;
     }
 
-    public function getIssues()
+    public function getIssues(): array
     {
         return $this->issues;
     }
 
     public function toArray(): array
     {
-        return [];
+        return [
+            self::ISSUES => array_map(fn (Issue $issue) => $issue->toArray(), $this->issues),
+        ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Search.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Search.php
@@ -6,12 +6,14 @@ final class Search implements ApiResponse
 {
     const ISSUES = 'issues';
 
+    /** @var array<int, Issue> */
     private array $issues = [];
 
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data = []): self
     {
         $issues = [];
@@ -22,18 +24,24 @@ final class Search implements ApiResponse
             }
         }
 
-        $model = new self();
+        $model = new self;
 
         $model->issues = $issues;
 
         return $model;
     }
 
+    /**
+     * @return array<int, Issue>
+     */
     public function getIssues(): array
     {
         return $this->issues;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [

--- a/src/CaptureHigherEd/LaravelJira/Models/Status.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Status.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Status implements ApiResponse
+{
+    const ID = 'id';
+
+    const NAME = 'name';
+
+    const DESCRIPTION = 'description';
+
+    const ICON_URL = 'iconUrl';
+
+    const SELF = 'self';
+
+    const STATUS_CATEGORY = 'statusCategory';
+
+    private string $id = '';
+
+    private string $name = '';
+
+    private string $description = '';
+
+    private string $iconUrl = '';
+
+    private string $self = '';
+
+    /** @var array<string, mixed> */
+    private array $statusCategory = [];
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->setId($data[self::ID] ?? '');
+        $model->setName($data[self::NAME] ?? '');
+        $model->setDescription($data[self::DESCRIPTION] ?? '');
+        $model->setIconUrl($data[self::ICON_URL] ?? '');
+        $model->setSelf($data[self::SELF] ?? '');
+        $model->setStatusCategory($data[self::STATUS_CATEGORY] ?? []);
+
+        return $model;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getIconUrl(): string
+    {
+        return $this->iconUrl;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getStatusCategory(): array
+    {
+        return $this->statusCategory;
+    }
+
+    public function setId(string $value): self
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    public function setName(string $value): self
+    {
+        $this->name = $value;
+
+        return $this;
+    }
+
+    public function setDescription(string $value): self
+    {
+        $this->description = $value;
+
+        return $this;
+    }
+
+    public function setIconUrl(string $value): self
+    {
+        $this->iconUrl = $value;
+
+        return $this;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public function setStatusCategory(array $value): self
+    {
+        $this->statusCategory = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            self::ID => $this->id,
+            self::NAME => $this->name,
+            self::DESCRIPTION => $this->description,
+            self::ICON_URL => $this->iconUrl,
+            self::SELF => $this->self,
+            self::STATUS_CATEGORY => $this->statusCategory,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/User.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/User.php
@@ -11,21 +11,21 @@ final class User implements ApiResponse
 
     private string $key = '';
     private string $email = '';
-    private string $active = '';
+    private bool $active = false;
     private string $name = '';
 
     private function __construct()
     {
     }
 
-    public static function make(?array $data = []): self
+    public static function make(array $data = []): self
     {
         $model = new self();
 
         $model->setKey($data[self::KEY] ?? '');
         $model->setName($data[self::NAME] ?? '');
         $model->setEmail($data[self::EMAIL] ?? '');
-        $model->setActive($data[self::ACTIVE] ?? '');
+        $model->setActive($data[self::ACTIVE] ?? false);
 
         return $model;
     }
@@ -35,7 +35,7 @@ final class User implements ApiResponse
         return $this->key;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -45,33 +45,33 @@ final class User implements ApiResponse
         return $this->email;
     }
 
-    public function getActive(): string
+    public function getActive(): bool
     {
         return $this->active;
     }
 
-    public function setKey($value): self
+    public function setKey(string $value): self
     {
         $this->key = $value;
 
         return $this;
     }
 
-    public function setName($value): self
+    public function setName(string $value): self
     {
         $this->name = $value;
 
         return $this;
     }
 
-    public function setEmail($value): self
+    public function setEmail(string $value): self
     {
         $this->email = $value;
 
         return $this;
     }
 
-    public function setActive($value): self
+    public function setActive(bool $value): self
     {
         $this->active = $value;
 
@@ -80,6 +80,11 @@ final class User implements ApiResponse
 
     public function toArray(): array
     {
-        return [];
+        return [
+            self::KEY    => $this->key,
+            self::NAME   => $this->name,
+            self::EMAIL  => $this->email,
+            self::ACTIVE => $this->active,
+        ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/User.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/User.php
@@ -5,22 +5,29 @@ namespace CaptureHigherEd\LaravelJira\Models;
 final class User implements ApiResponse
 {
     const NAME = 'displayName';
+
     const KEY = 'accountId';
+
     const EMAIL = 'emailAddress';
+
     const ACTIVE = 'active';
 
     private string $key = '';
+
     private string $email = '';
+
     private bool $active = false;
+
     private string $name = '';
 
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data = []): self
     {
-        $model = new self();
+        $model = new self;
 
         $model->setKey($data[self::KEY] ?? '');
         $model->setName($data[self::NAME] ?? '');
@@ -78,12 +85,15 @@ final class User implements ApiResponse
         return $this;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [
-            self::KEY    => $this->key,
-            self::NAME   => $this->name,
-            self::EMAIL  => $this->email,
+            self::KEY => $this->key,
+            self::NAME => $this->name,
+            self::EMAIL => $this->email,
             self::ACTIVE => $this->active,
         ];
     }

--- a/src/CaptureHigherEd/LaravelJira/Models/User.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/User.php
@@ -12,6 +12,16 @@ final class User implements ApiResponse
 
     const ACTIVE = 'active';
 
+    const SELF = 'self';
+
+    const ACCOUNT_TYPE = 'accountType';
+
+    const TIME_ZONE = 'timeZone';
+
+    const LOCALE = 'locale';
+
+    const AVATAR_URLS = 'avatarUrls';
+
     private string $key = '';
 
     private string $email = '';
@@ -19,6 +29,17 @@ final class User implements ApiResponse
     private bool $active = false;
 
     private string $name = '';
+
+    private string $self = '';
+
+    private string $accountType = '';
+
+    private string $timeZone = '';
+
+    private string $locale = '';
+
+    /** @var array<string, string> */
+    private array $avatarUrls = [];
 
     private function __construct() {}
 
@@ -33,6 +54,11 @@ final class User implements ApiResponse
         $model->setName($data[self::NAME] ?? '');
         $model->setEmail($data[self::EMAIL] ?? '');
         $model->setActive($data[self::ACTIVE] ?? false);
+        $model->setSelf($data[self::SELF] ?? '');
+        $model->setAccountType($data[self::ACCOUNT_TYPE] ?? '');
+        $model->setTimeZone($data[self::TIME_ZONE] ?? '');
+        $model->setLocale($data[self::LOCALE] ?? '');
+        $model->setAvatarUrls($data[self::AVATAR_URLS] ?? []);
 
         return $model;
     }
@@ -55,6 +81,34 @@ final class User implements ApiResponse
     public function getActive(): bool
     {
         return $this->active;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    public function getAccountType(): string
+    {
+        return $this->accountType;
+    }
+
+    public function getTimeZone(): string
+    {
+        return $this->timeZone;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAvatarUrls(): array
+    {
+        return $this->avatarUrls;
     }
 
     public function setKey(string $value): self
@@ -85,6 +139,44 @@ final class User implements ApiResponse
         return $this;
     }
 
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    public function setAccountType(string $value): self
+    {
+        $this->accountType = $value;
+
+        return $this;
+    }
+
+    public function setTimeZone(string $value): self
+    {
+        $this->timeZone = $value;
+
+        return $this;
+    }
+
+    public function setLocale(string $value): self
+    {
+        $this->locale = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, string>  $value
+     */
+    public function setAvatarUrls(array $value): self
+    {
+        $this->avatarUrls = $value;
+
+        return $this;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -95,6 +187,11 @@ final class User implements ApiResponse
             self::NAME => $this->name,
             self::EMAIL => $this->email,
             self::ACTIVE => $this->active,
+            self::SELF => $this->self,
+            self::ACCOUNT_TYPE => $this->accountType,
+            self::TIME_ZONE => $this->timeZone,
+            self::LOCALE => $this->locale,
+            self::AVATAR_URLS => $this->avatarUrls,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Users.php
@@ -2,15 +2,16 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-
 final class Users implements ApiResponse
 {
+    /** @var array<int, User> */
     private array $users = [];
 
-    private function __construct()
-    {
-    }
+    private function __construct() {}
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data = []): self
     {
         $users = [];
@@ -19,18 +20,24 @@ final class Users implements ApiResponse
             $users[] = User::make($item);
         }
 
-        $model = new self();
+        $model = new self;
 
         $model->users = $users;
 
         return $model;
     }
 
+    /**
+     * @return array<int, User>
+     */
     public function getUsers(): array
     {
         return $this->users;
     }
 
+    /**
+     * @return array<int, User>
+     */
     public function getActiveUsers(): array
     {
         return array_filter($this->users, static function (User $user): bool {
@@ -38,6 +45,9 @@ final class Users implements ApiResponse
         });
     }
 
+    /**
+     * @return array<int, array<string, mixed>>
+     */
     public function toArray(): array
     {
         return array_map(fn (User $user) => $user->toArray(), $this->users);

--- a/src/CaptureHigherEd/LaravelJira/Models/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Users.php
@@ -11,7 +11,7 @@ final class Users implements ApiResponse
     {
     }
 
-    public static function make(?array $data = []): self
+    public static function make(array $data = []): self
     {
         $users = [];
 
@@ -26,12 +26,12 @@ final class Users implements ApiResponse
         return $model;
     }
 
-    public function getUsers()
+    public function getUsers(): array
     {
         return $this->users;
     }
 
-    public function getActiveUsers()
+    public function getActiveUsers(): array
     {
         return array_filter($this->users, static function (User $user): bool {
             return $user->getActive();
@@ -40,6 +40,6 @@ final class Users implements ApiResponse
 
     public function toArray(): array
     {
-        return [];
+        return array_map(fn (User $user) => $user->toArray(), $this->users);
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Providers/IntegrationServiceProvider.php
+++ b/src/CaptureHigherEd/LaravelJira/Providers/IntegrationServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace CaptureHigherEd\LaravelJira\Providers;
 
-use App\Http\Kernel;
 use Illuminate\Support\ServiceProvider;
 use CaptureHigherEd\LaravelJira\Jira as JiraService;
 use Illuminate\Contracts\Support\DeferrableProvider;
@@ -14,7 +13,7 @@ class IntegrationServiceProvider extends ServiceProvider implements DeferrablePr
      *
      * @return void
      */
-    public function boot(Kernel $kernel)
+    public function boot(): void
     {
     }
 
@@ -33,7 +32,7 @@ class IntegrationServiceProvider extends ServiceProvider implements DeferrablePr
      *
      * @return array
      */
-    public function provides()
+    public function provides(): array
     {
         return [JiraService::class];
     }

--- a/src/CaptureHigherEd/LaravelJira/Providers/IntegrationServiceProvider.php
+++ b/src/CaptureHigherEd/LaravelJira/Providers/IntegrationServiceProvider.php
@@ -2,20 +2,16 @@
 
 namespace CaptureHigherEd\LaravelJira\Providers;
 
-use Illuminate\Support\ServiceProvider;
 use CaptureHigherEd\LaravelJira\Jira as JiraService;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Support\ServiceProvider;
 
 class IntegrationServiceProvider extends ServiceProvider implements DeferrableProvider
 {
     /**
      * Bootstrap any application services.
-     *
-     * @return void
      */
-    public function boot(): void
-    {
-    }
+    public function boot(): void {}
 
     /**
      * Register any application services.
@@ -30,7 +26,7 @@ class IntegrationServiceProvider extends ServiceProvider implements DeferrablePr
     /**
      * Get the services provided by the provider.
      *
-     * @return array
+     * @return array<string>
      */
     public function provides(): array
     {
@@ -44,7 +40,7 @@ class IntegrationServiceProvider extends ServiceProvider implements DeferrablePr
      */
     public function registerJiraService()
     {
-        $config = __DIR__ . '/../config/jira.php';
+        $config = __DIR__.'/../config/jira.php';
         $this->mergeConfigFrom($config, 'jira');
         $this->publishes([$config => config_path('jira.php')]);
 

--- a/src/CaptureHigherEd/LaravelJira/config/jira.php
+++ b/src/CaptureHigherEd/LaravelJira/config/jira.php
@@ -3,11 +3,12 @@
 return [
 
     /**
-     * Personal access token to use for jira service
+     * Atlassian API Token for authenticating with the Jira REST API.
      *
-     * This should be a base64 encoded string in the format "test@[domain]:jiraPersonalAccessToken"
+     * This is auto-built from JIRA_API_EMAIL and JIRA_API_TOKEN as a base64-encoded
+     * "email:token" string (HTTP Basic Auth format required by Atlassian Cloud).
      *
-     * @link https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
+     * To generate a token: https://id.atlassian.com/manage-profile/security/api-tokens
      */
     'token' => env("JIRA_API_EMAIL") && env("JIRA_API_TOKEN")
         ? base64_encode(trim(env("JIRA_API_EMAIL") . ':' . env("JIRA_API_TOKEN")))

--- a/src/CaptureHigherEd/LaravelJira/config/jira.php
+++ b/src/CaptureHigherEd/LaravelJira/config/jira.php
@@ -10,12 +10,12 @@ return [
      *
      * To generate a token: https://id.atlassian.com/manage-profile/security/api-tokens
      */
-    'token' => env("JIRA_API_EMAIL") && env("JIRA_API_TOKEN")
-        ? base64_encode(trim(env("JIRA_API_EMAIL") . ':' . env("JIRA_API_TOKEN")))
+    'token' => env('JIRA_API_EMAIL') && env('JIRA_API_TOKEN')
+        ? base64_encode(trim(env('JIRA_API_EMAIL').':'.env('JIRA_API_TOKEN')))
         : null,
 
     /**
      * Jira domain: ex. https://[client name].atlassian.net
      */
-    'domain' => env("JIRA_API_DOMAIN")
+    'domain' => env('JIRA_API_DOMAIN'),
 ];

--- a/tests/Api/FieldsTest.php
+++ b/tests/Api/FieldsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Api;
+
+use CaptureHigherEd\LaravelJira\Api\Fields;
+use CaptureHigherEd\LaravelJira\Models\Field;
+use CaptureHigherEd\LaravelJira\Models\Fields as ModelsFields;
+use CaptureHigherEd\LaravelJira\Providers\IntegrationServiceProvider;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use Orchestra\Testbench\TestCase;
+
+class FieldsTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    protected function getPackageProviders($app): array
+    {
+        return [IntegrationServiceProvider::class];
+    }
+
+    /** @return array<string, mixed> */
+    private function createMetaResponse(): array
+    {
+        return [
+            'projects' => [
+                [
+                    'key' => 'CBE4',
+                    'issuetypes' => [
+                        [
+                            'name' => 'Bug',
+                            'fields' => [
+                                'customfield_10001' => [
+                                    'allowedValues' => [
+                                        ['value' => 'Option A'],
+                                        ['value' => 'Option B'],
+                                        ['value' => 'Option C'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'key' => 'OTHER',
+                    'issuetypes' => [],
+                ],
+            ],
+        ];
+    }
+
+    public function test_index(): void
+    {
+        $fieldData = [
+            ['id' => 'summary', 'key' => 'summary', 'name' => 'Summary', 'custom' => false, 'orderable' => true, 'navigable' => true, 'searchable' => true, 'clauseNames' => [], 'schema' => []],
+        ];
+        $response = $this->jsonResponse($fieldData);
+        $client = $this->mockClientExpecting('GET', 'field', ['query' => []], $response);
+        $api = new Fields($client);
+
+        $result = $api->index();
+
+        $this->assertInstanceOf(ModelsFields::class, $result);
+        $this->assertCount(1, $result->getFields());
+    }
+
+    public function test_get_field_options_happy_path(): void
+    {
+        $meta = $this->createMetaResponse();
+        $response = $this->jsonResponse($meta);
+        $client = $this->mockClientExpecting('GET', 'issue/createmeta', ['query' => ['expand' => 'projects.issuetypes.fields']], $response);
+        $api = new Fields($client);
+
+        $field = Field::make(['id' => 'customfield_10001', 'key' => 'customfield_10001', 'name' => 'Priority', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
+        $result = $api->getFieldOptions($field, 'CBE4', 'Bug');
+
+        $this->assertSame(['Option A' => 'Option A', 'Option B' => 'Option B', 'Option C' => 'Option C'], $result);
+    }
+
+    public function test_get_field_options_project_not_found(): void
+    {
+        $meta = $this->createMetaResponse();
+        $response = $this->jsonResponse($meta);
+        $client = $this->mockClientExpecting('GET', 'issue/createmeta', ['query' => ['expand' => 'projects.issuetypes.fields']], $response);
+        $api = new Fields($client);
+
+        $field = Field::make(['id' => 'customfield_10001', 'key' => 'customfield_10001', 'name' => 'Priority', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
+        $result = $api->getFieldOptions($field, 'NONEXISTENT', 'Bug');
+
+        $this->assertSame([], $result);
+    }
+
+    public function test_get_field_options_issue_type_not_found(): void
+    {
+        $meta = $this->createMetaResponse();
+        $response = $this->jsonResponse($meta);
+        $client = $this->mockClientExpecting('GET', 'issue/createmeta', ['query' => ['expand' => 'projects.issuetypes.fields']], $response);
+        $api = new Fields($client);
+
+        $field = Field::make(['id' => 'customfield_10001', 'key' => 'customfield_10001', 'name' => 'Priority', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
+        $result = $api->getFieldOptions($field, 'CBE4', 'Story');
+
+        $this->assertSame([], $result);
+    }
+
+    public function test_get_field_options_field_not_found(): void
+    {
+        $meta = $this->createMetaResponse();
+        $response = $this->jsonResponse($meta);
+        $client = $this->mockClientExpecting('GET', 'issue/createmeta', ['query' => ['expand' => 'projects.issuetypes.fields']], $response);
+        $api = new Fields($client);
+
+        $field = Field::make(['id' => 'customfield_99999', 'key' => 'customfield_99999', 'name' => 'Nonexistent', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
+        $result = $api->getFieldOptions($field, 'CBE4', 'Bug');
+
+        $this->assertSame([], $result);
+    }
+}

--- a/tests/Api/FieldsTest.php
+++ b/tests/Api/FieldsTest.php
@@ -5,21 +5,17 @@ namespace CaptureHigherEd\LaravelJira\Tests\Api;
 use CaptureHigherEd\LaravelJira\Api\Fields;
 use CaptureHigherEd\LaravelJira\Models\Field;
 use CaptureHigherEd\LaravelJira\Models\Fields as ModelsFields;
-use CaptureHigherEd\LaravelJira\Providers\IntegrationServiceProvider;
 use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\UsesTestbench;
 use Orchestra\Testbench\TestCase;
 
 class FieldsTest extends TestCase
 {
     use MocksHttpResponses;
-
-    protected function getPackageProviders($app): array
-    {
-        return [IntegrationServiceProvider::class];
-    }
+    use UsesTestbench;
 
     /** @return array<string, mixed> */
-    private function createMetaResponse(): array
+    private function createMetaData(): array
     {
         return [
             'projects' => [
@@ -48,6 +44,21 @@ class FieldsTest extends TestCase
         ];
     }
 
+    private function makeCustomField(string $id): Field
+    {
+        return Field::make(['id' => $id, 'key' => $id, 'name' => $id, 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
+    }
+
+    private function makeFieldsApiWithCreateMeta(): Fields
+    {
+        $response = $this->jsonResponse($this->createMetaData());
+        $client = $this->mockClientExpecting('GET', 'issue/createmeta', ['query' => ['expand' => 'projects.issuetypes.fields']], $response);
+
+        return new Fields($client);
+    }
+
+    // ── index ─────────────────────────────────────────────────────────────
+
     public function test_index(): void
     {
         $fieldData = [
@@ -63,55 +74,51 @@ class FieldsTest extends TestCase
         $this->assertCount(1, $result->getFields(), 'Fields::index() should return exactly 1 field from the response');
     }
 
+    // ── getFieldOptions ───────────────────────────────────────────────────
+
     public function test_get_field_options_happy_path(): void
     {
-        $meta = $this->createMetaResponse();
-        $response = $this->jsonResponse($meta);
-        $client = $this->mockClientExpecting('GET', 'issue/createmeta', ['query' => ['expand' => 'projects.issuetypes.fields']], $response);
-        $api = new Fields($client);
+        $api = $this->makeFieldsApiWithCreateMeta();
+        $field = $this->makeCustomField('customfield_10001');
 
-        $field = Field::make(['id' => 'customfield_10001', 'key' => 'customfield_10001', 'name' => 'Priority', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
         $result = $api->getFieldOptions($field, 'CBE4', 'Bug');
 
         $this->assertSame(['Option A' => 'Option A', 'Option B' => 'Option B', 'Option C' => 'Option C'], $result, 'getFieldOptions() should return allowed values keyed and valued by their value string');
     }
 
-    public function test_get_field_options_project_not_found(): void
+    /** @dataProvider fieldOptionsNotFoundProvider */
+    public function test_get_field_options_not_found(string $fieldId, string $projectKey, string $issueType, string $message): void
     {
-        $meta = $this->createMetaResponse();
-        $response = $this->jsonResponse($meta);
-        $client = $this->mockClientExpecting('GET', 'issue/createmeta', ['query' => ['expand' => 'projects.issuetypes.fields']], $response);
-        $api = new Fields($client);
+        $api = $this->makeFieldsApiWithCreateMeta();
+        $field = $this->makeCustomField($fieldId);
 
-        $field = Field::make(['id' => 'customfield_10001', 'key' => 'customfield_10001', 'name' => 'Priority', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
-        $result = $api->getFieldOptions($field, 'NONEXISTENT', 'Bug');
+        $result = $api->getFieldOptions($field, $projectKey, $issueType);
 
-        $this->assertSame([], $result, 'getFieldOptions() should return an empty array when the specified project key does not exist in the metadata');
+        $this->assertSame([], $result, $message);
     }
 
-    public function test_get_field_options_issue_type_not_found(): void
+    /** @return array<string, array{string, string, string, string}> */
+    public static function fieldOptionsNotFoundProvider(): array
     {
-        $meta = $this->createMetaResponse();
-        $response = $this->jsonResponse($meta);
-        $client = $this->mockClientExpecting('GET', 'issue/createmeta', ['query' => ['expand' => 'projects.issuetypes.fields']], $response);
-        $api = new Fields($client);
-
-        $field = Field::make(['id' => 'customfield_10001', 'key' => 'customfield_10001', 'name' => 'Priority', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
-        $result = $api->getFieldOptions($field, 'CBE4', 'Story');
-
-        $this->assertSame([], $result, 'getFieldOptions() should return an empty array when the specified issue type does not exist in the project');
-    }
-
-    public function test_get_field_options_field_not_found(): void
-    {
-        $meta = $this->createMetaResponse();
-        $response = $this->jsonResponse($meta);
-        $client = $this->mockClientExpecting('GET', 'issue/createmeta', ['query' => ['expand' => 'projects.issuetypes.fields']], $response);
-        $api = new Fields($client);
-
-        $field = Field::make(['id' => 'customfield_99999', 'key' => 'customfield_99999', 'name' => 'Nonexistent', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
-        $result = $api->getFieldOptions($field, 'CBE4', 'Bug');
-
-        $this->assertSame([], $result, 'getFieldOptions() should return an empty array when the field ID does not exist in the issue type fields');
+        return [
+            'project not found' => [
+                'customfield_10001',
+                'NONEXISTENT',
+                'Bug',
+                'getFieldOptions() should return an empty array when the specified project key does not exist in the metadata',
+            ],
+            'issue type not found' => [
+                'customfield_10001',
+                'CBE4',
+                'Story',
+                'getFieldOptions() should return an empty array when the specified issue type does not exist in the project',
+            ],
+            'field not found' => [
+                'customfield_99999',
+                'CBE4',
+                'Bug',
+                'getFieldOptions() should return an empty array when the field ID does not exist in the issue type fields',
+            ],
+        ];
     }
 }

--- a/tests/Api/FieldsTest.php
+++ b/tests/Api/FieldsTest.php
@@ -59,8 +59,8 @@ class FieldsTest extends TestCase
 
         $result = $api->index();
 
-        $this->assertInstanceOf(ModelsFields::class, $result);
-        $this->assertCount(1, $result->getFields());
+        $this->assertInstanceOf(ModelsFields::class, $result, 'Fields::index() should return a Fields model instance');
+        $this->assertCount(1, $result->getFields(), 'Fields::index() should return exactly 1 field from the response');
     }
 
     public function test_get_field_options_happy_path(): void
@@ -73,7 +73,7 @@ class FieldsTest extends TestCase
         $field = Field::make(['id' => 'customfield_10001', 'key' => 'customfield_10001', 'name' => 'Priority', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
         $result = $api->getFieldOptions($field, 'CBE4', 'Bug');
 
-        $this->assertSame(['Option A' => 'Option A', 'Option B' => 'Option B', 'Option C' => 'Option C'], $result);
+        $this->assertSame(['Option A' => 'Option A', 'Option B' => 'Option B', 'Option C' => 'Option C'], $result, 'getFieldOptions() should return allowed values keyed and valued by their value string');
     }
 
     public function test_get_field_options_project_not_found(): void
@@ -86,7 +86,7 @@ class FieldsTest extends TestCase
         $field = Field::make(['id' => 'customfield_10001', 'key' => 'customfield_10001', 'name' => 'Priority', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
         $result = $api->getFieldOptions($field, 'NONEXISTENT', 'Bug');
 
-        $this->assertSame([], $result);
+        $this->assertSame([], $result, 'getFieldOptions() should return an empty array when the specified project key does not exist in the metadata');
     }
 
     public function test_get_field_options_issue_type_not_found(): void
@@ -99,7 +99,7 @@ class FieldsTest extends TestCase
         $field = Field::make(['id' => 'customfield_10001', 'key' => 'customfield_10001', 'name' => 'Priority', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
         $result = $api->getFieldOptions($field, 'CBE4', 'Story');
 
-        $this->assertSame([], $result);
+        $this->assertSame([], $result, 'getFieldOptions() should return an empty array when the specified issue type does not exist in the project');
     }
 
     public function test_get_field_options_field_not_found(): void
@@ -112,6 +112,6 @@ class FieldsTest extends TestCase
         $field = Field::make(['id' => 'customfield_99999', 'key' => 'customfield_99999', 'name' => 'Nonexistent', 'custom' => true, 'orderable' => false, 'navigable' => false, 'searchable' => false, 'clauseNames' => [], 'schema' => []]);
         $result = $api->getFieldOptions($field, 'CBE4', 'Bug');
 
-        $this->assertSame([], $result);
+        $this->assertSame([], $result, 'getFieldOptions() should return an empty array when the field ID does not exist in the issue type fields');
     }
 }

--- a/tests/Api/HttpApiTest.php
+++ b/tests/Api/HttpApiTest.php
@@ -65,8 +65,8 @@ class HttpApiTest extends TestCase
 
         $result = $api->callHydrateResponse($response, Search::class);
 
-        $this->assertInstanceOf(Search::class, $result);
-        $this->assertCount(1, $result->getIssues());
+        $this->assertInstanceOf(Search::class, $result, 'hydrateResponse() should return a Search instance when given a 200 response and the Search class');
+        $this->assertCount(1, $result->getIssues(), 'Hydrated Search result should contain exactly 1 issue from the response body');
     }
 
     public function test_hydrate_201_with_class(): void
@@ -76,7 +76,7 @@ class HttpApiTest extends TestCase
 
         $result = $api->callHydrateResponse($response, Search::class);
 
-        $this->assertInstanceOf(Search::class, $result);
+        $this->assertInstanceOf(Search::class, $result, 'hydrateResponse() should return a Search instance when given a 201 Created response');
     }
 
     public function test_hydrate_204_with_class(): void
@@ -86,8 +86,8 @@ class HttpApiTest extends TestCase
 
         $result = $api->callHydrateResponse($response, Search::class);
 
-        $this->assertInstanceOf(Search::class, $result);
-        $this->assertSame([], $result->getIssues());
+        $this->assertInstanceOf(Search::class, $result, 'hydrateResponse() should return an empty hydrated instance when given a 204 No Content response with a class');
+        $this->assertSame([], $result->getIssues(), 'Hydrated Search from a 204 response should have an empty issues array');
     }
 
     public function test_hydrate_204_without_class(): void
@@ -97,7 +97,7 @@ class HttpApiTest extends TestCase
 
         $result = $api->callHydrateResponse($response);
 
-        $this->assertSame([], $result);
+        $this->assertSame([], $result, 'hydrateResponse() should return an empty array when given a 204 No Content response without a class');
     }
 
     public function test_hydrate_empty_body_with_class(): void
@@ -107,7 +107,7 @@ class HttpApiTest extends TestCase
 
         $result = $api->callHydrateResponse($response, Search::class);
 
-        $this->assertInstanceOf(Search::class, $result);
+        $this->assertInstanceOf(Search::class, $result, 'hydrateResponse() should return an empty hydrated instance when the response body is empty and a class is provided');
     }
 
     public function test_hydrate_empty_body_without_class(): void
@@ -117,7 +117,7 @@ class HttpApiTest extends TestCase
 
         $result = $api->callHydrateResponse($response);
 
-        $this->assertSame([], $result);
+        $this->assertSame([], $result, 'hydrateResponse() should return an empty array when the response body is empty and no class is provided');
     }
 
     public function test_hydrate_200_without_class(): void
@@ -128,7 +128,7 @@ class HttpApiTest extends TestCase
 
         $result = $api->callHydrateResponse($response);
 
-        $this->assertSame($data, $result);
+        $this->assertSame($data, $result, 'hydrateResponse() should return the raw decoded array when no class is provided');
     }
 
     public function test_hydrate_invalid_json_returns_empty_array(): void
@@ -138,7 +138,7 @@ class HttpApiTest extends TestCase
 
         $result = $api->callHydrateResponse($response);
 
-        $this->assertSame([], $result);
+        $this->assertSame([], $result, 'hydrateResponse() should return an empty array when the response body contains invalid JSON');
     }
 
     // ── handleErrors ─────────────────────────────────────────────────────

--- a/tests/Api/HttpApiTest.php
+++ b/tests/Api/HttpApiTest.php
@@ -15,6 +15,12 @@ class HttpApiTest extends TestCase
     use MocksHttpResponses;
 
     /** @return HttpApi&object{callHydrateResponse: callable, callHandleErrors: callable, callHttpGet: callable, callHttpPost: callable, callHttpPut: callable, callHttpDelete: callable, callHttpPostWithAttachments: callable} */
+    private function makeApiWithResponse(ResponseInterface $response): object
+    {
+        return $this->makeApi($this->mockClient($response));
+    }
+
+    /** @return HttpApi&object{callHydrateResponse: callable, callHandleErrors: callable, callHttpGet: callable, callHttpPost: callable, callHttpPut: callable, callHttpDelete: callable, callHttpPostWithAttachments: callable} */
     private function makeApi(ClientInterface $client): object
     {
         return new class($client) extends HttpApi
@@ -61,7 +67,7 @@ class HttpApiTest extends TestCase
     public function test_hydrate_200_with_class(): void
     {
         $response = $this->jsonResponse(['issues' => [['id' => '1', 'key' => 'KEY-1', 'fields' => []]]]);
-        $api = $this->makeApi($this->mockClient($response));
+        $api = $this->makeApiWithResponse($response);
 
         $result = $api->callHydrateResponse($response, Search::class);
 
@@ -72,7 +78,7 @@ class HttpApiTest extends TestCase
     public function test_hydrate_201_with_class(): void
     {
         $response = $this->mockResponse(201, ['id' => '10', 'key' => 'KEY-10', 'fields' => []]);
-        $api = $this->makeApi($this->mockClient($response));
+        $api = $this->makeApiWithResponse($response);
 
         $result = $api->callHydrateResponse($response, Search::class);
 
@@ -82,7 +88,7 @@ class HttpApiTest extends TestCase
     public function test_hydrate_204_with_class(): void
     {
         $response = $this->noContentResponse();
-        $api = $this->makeApi($this->mockClient($response));
+        $api = $this->makeApiWithResponse($response);
 
         $result = $api->callHydrateResponse($response, Search::class);
 
@@ -93,7 +99,7 @@ class HttpApiTest extends TestCase
     public function test_hydrate_204_without_class(): void
     {
         $response = $this->noContentResponse();
-        $api = $this->makeApi($this->mockClient($response));
+        $api = $this->makeApiWithResponse($response);
 
         $result = $api->callHydrateResponse($response);
 
@@ -103,7 +109,7 @@ class HttpApiTest extends TestCase
     public function test_hydrate_empty_body_with_class(): void
     {
         $response = $this->mockResponse(200, '');
-        $api = $this->makeApi($this->mockClient($response));
+        $api = $this->makeApiWithResponse($response);
 
         $result = $api->callHydrateResponse($response, Search::class);
 
@@ -113,7 +119,7 @@ class HttpApiTest extends TestCase
     public function test_hydrate_empty_body_without_class(): void
     {
         $response = $this->mockResponse(200, '');
-        $api = $this->makeApi($this->mockClient($response));
+        $api = $this->makeApiWithResponse($response);
 
         $result = $api->callHydrateResponse($response);
 
@@ -124,7 +130,7 @@ class HttpApiTest extends TestCase
     {
         $data = ['key' => 'value', 'count' => 3];
         $response = $this->jsonResponse($data);
-        $api = $this->makeApi($this->mockClient($response));
+        $api = $this->makeApiWithResponse($response);
 
         $result = $api->callHydrateResponse($response);
 
@@ -134,7 +140,7 @@ class HttpApiTest extends TestCase
     public function test_hydrate_invalid_json_returns_empty_array(): void
     {
         $response = $this->mockResponse(200, 'not-valid-json', ['Content-Type' => 'application/json']);
-        $api = $this->makeApi($this->mockClient($response));
+        $api = $this->makeApiWithResponse($response);
 
         $result = $api->callHydrateResponse($response);
 
@@ -147,7 +153,7 @@ class HttpApiTest extends TestCase
     public function test_handle_errors_throws_for_status(int $status): void
     {
         $response = $this->plainErrorResponse($status, 'error');
-        $api = $this->makeApi($this->mockClient($response));
+        $api = $this->makeApiWithResponse($response);
 
         $this->expectException(HttpClientException::class);
 

--- a/tests/Api/HttpApiTest.php
+++ b/tests/Api/HttpApiTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Api;
+
+use CaptureHigherEd\LaravelJira\Api\HttpApi;
+use CaptureHigherEd\LaravelJira\Exception\HttpClientException;
+use CaptureHigherEd\LaravelJira\Models\Search;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+class HttpApiTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    /** @return HttpApi&object{callHydrateResponse: callable, callHandleErrors: callable, callHttpGet: callable, callHttpPost: callable, callHttpPut: callable, callHttpDelete: callable, callHttpPostWithAttachments: callable} */
+    private function makeApi(ClientInterface $client): object
+    {
+        return new class($client) extends HttpApi
+        {
+            public function callHydrateResponse(ResponseInterface $response, ?string $class = null): mixed
+            {
+                return $this->hydrateResponse($response, $class);
+            }
+
+            public function callHandleErrors(ResponseInterface $response): void
+            {
+                $this->handleErrors($response);
+            }
+
+            public function callHttpGet(string $path, array $parameters = []): ResponseInterface
+            {
+                return $this->httpGet($path, $parameters);
+            }
+
+            public function callHttpPost(string $path, array $parameters = []): ResponseInterface
+            {
+                return $this->httpPost($path, $parameters);
+            }
+
+            public function callHttpPut(string $path, array $parameters = []): ResponseInterface
+            {
+                return $this->httpPut($path, $parameters);
+            }
+
+            public function callHttpDelete(string $path): ResponseInterface
+            {
+                return $this->httpDelete($path);
+            }
+
+            public function callHttpPostWithAttachments(string $path, array $multipart = []): ResponseInterface
+            {
+                return $this->httpPostWithAttachments($path, $multipart);
+            }
+        };
+    }
+
+    // ── hydrateResponse ──────────────────────────────────────────────────
+
+    public function test_hydrate_200_with_class(): void
+    {
+        $response = $this->jsonResponse(['issues' => [['id' => '1', 'key' => 'KEY-1', 'fields' => []]]]);
+        $api = $this->makeApi($this->mockClient($response));
+
+        $result = $api->callHydrateResponse($response, Search::class);
+
+        $this->assertInstanceOf(Search::class, $result);
+        $this->assertCount(1, $result->getIssues());
+    }
+
+    public function test_hydrate_201_with_class(): void
+    {
+        $response = $this->mockResponse(201, ['id' => '10', 'key' => 'KEY-10', 'fields' => []]);
+        $api = $this->makeApi($this->mockClient($response));
+
+        $result = $api->callHydrateResponse($response, Search::class);
+
+        $this->assertInstanceOf(Search::class, $result);
+    }
+
+    public function test_hydrate_204_with_class(): void
+    {
+        $response = $this->noContentResponse();
+        $api = $this->makeApi($this->mockClient($response));
+
+        $result = $api->callHydrateResponse($response, Search::class);
+
+        $this->assertInstanceOf(Search::class, $result);
+        $this->assertSame([], $result->getIssues());
+    }
+
+    public function test_hydrate_204_without_class(): void
+    {
+        $response = $this->noContentResponse();
+        $api = $this->makeApi($this->mockClient($response));
+
+        $result = $api->callHydrateResponse($response);
+
+        $this->assertSame([], $result);
+    }
+
+    public function test_hydrate_empty_body_with_class(): void
+    {
+        $response = $this->mockResponse(200, '');
+        $api = $this->makeApi($this->mockClient($response));
+
+        $result = $api->callHydrateResponse($response, Search::class);
+
+        $this->assertInstanceOf(Search::class, $result);
+    }
+
+    public function test_hydrate_empty_body_without_class(): void
+    {
+        $response = $this->mockResponse(200, '');
+        $api = $this->makeApi($this->mockClient($response));
+
+        $result = $api->callHydrateResponse($response);
+
+        $this->assertSame([], $result);
+    }
+
+    public function test_hydrate_200_without_class(): void
+    {
+        $data = ['key' => 'value', 'count' => 3];
+        $response = $this->jsonResponse($data);
+        $api = $this->makeApi($this->mockClient($response));
+
+        $result = $api->callHydrateResponse($response);
+
+        $this->assertSame($data, $result);
+    }
+
+    public function test_hydrate_invalid_json_returns_empty_array(): void
+    {
+        $response = $this->mockResponse(200, 'not-valid-json', ['Content-Type' => 'application/json']);
+        $api = $this->makeApi($this->mockClient($response));
+
+        $result = $api->callHydrateResponse($response);
+
+        $this->assertSame([], $result);
+    }
+
+    // ── handleErrors ─────────────────────────────────────────────────────
+
+    /** @dataProvider errorStatusProvider */
+    public function test_handle_errors_throws_for_status(int $status): void
+    {
+        $response = $this->plainErrorResponse($status, 'error');
+        $api = $this->makeApi($this->mockClient($response));
+
+        $this->expectException(HttpClientException::class);
+
+        $api->callHandleErrors($response);
+    }
+
+    /** @return array<string, array{int}> */
+    public static function errorStatusProvider(): array
+    {
+        return [
+            '400' => [400],
+            '401' => [401],
+            '402' => [402],
+            '403' => [403],
+            '404' => [404],
+            '409' => [409],
+            '413' => [413],
+            '422' => [422],
+            '429' => [429],
+            '500' => [500],
+            '502' => [502],
+            '503' => [503],
+            '418 unknown' => [418],
+        ];
+    }
+
+    // ── HTTP verb delegation ──────────────────────────────────────────────
+
+    public function test_http_get_passes_query(): void
+    {
+        $response = $this->jsonResponse([]);
+        $client = $this->mockClientExpecting('GET', 'search', ['query' => ['jql' => 'project=CBE4']], $response);
+        $api = $this->makeApi($client);
+
+        $api->callHttpGet('search', ['jql' => 'project=CBE4']);
+    }
+
+    public function test_http_post_passes_json(): void
+    {
+        $response = $this->jsonResponse(['id' => '1', 'key' => 'KEY-1', 'fields' => []]);
+        $client = $this->mockClientExpecting('POST', 'issue', ['json' => ['fields' => ['summary' => 'Test']]], $response);
+        $api = $this->makeApi($client);
+
+        $api->callHttpPost('issue', ['fields' => ['summary' => 'Test']]);
+    }
+
+    public function test_http_put_passes_json(): void
+    {
+        $response = $this->jsonResponse(['id' => '1', 'key' => 'KEY-1', 'fields' => []]);
+        $client = $this->mockClientExpecting('PUT', 'issue/KEY-1', ['json' => ['fields' => ['summary' => 'Updated']]], $response);
+        $api = $this->makeApi($client);
+
+        $api->callHttpPut('issue/KEY-1', ['fields' => ['summary' => 'Updated']]);
+    }
+
+    public function test_http_delete_passes_path(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('DELETE', 'issue/KEY-1', [], $response);
+        $api = $this->makeApi($client);
+
+        $api->callHttpDelete('issue/KEY-1');
+    }
+
+    public function test_http_post_with_attachments_passes_multipart_and_headers(): void
+    {
+        $response = $this->jsonResponse([]);
+        $multipart = [['name' => 'file', 'contents' => 'file-data', 'filename' => 'test.txt']];
+        $client = $this->mockClientExpecting('POST', 'issue/KEY-1/attachments', [
+            'multipart' => $multipart,
+            'headers' => [
+                'Accept' => 'application/json',
+                'X-Atlassian-Token' => 'no-check',
+            ],
+        ], $response);
+        $api = $this->makeApi($client);
+
+        $api->callHttpPostWithAttachments('issue/KEY-1/attachments', $multipart);
+    }
+}

--- a/tests/Api/IssuesTest.php
+++ b/tests/Api/IssuesTest.php
@@ -14,6 +14,8 @@ class IssuesTest extends TestCase
 {
     use MocksHttpResponses;
 
+    // ── CRUD ──────────────────────────────────────────────────────────────
+
     public function test_index(): void
     {
         $response = $this->jsonResponse([
@@ -51,6 +53,8 @@ class IssuesTest extends TestCase
         $this->assertInstanceOf(Issue::class, $result, 'Issues::create() should return an Issue instance');
         $this->assertSame('KEY-11', $result->getKey(), 'Issues::create() should return the newly created issue with the correct key');
     }
+
+    // ── Attachments & comments ────────────────────────────────────────────
 
     public function test_attach(): void
     {
@@ -98,6 +102,8 @@ class IssuesTest extends TestCase
 
         $this->assertInstanceOf(Issue::class, $result, 'Issues::update() should return an Issue instance');
     }
+
+    // ── Metadata ──────────────────────────────────────────────────────────
 
     public function test_get_create_meta(): void
     {

--- a/tests/Api/IssuesTest.php
+++ b/tests/Api/IssuesTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Api;
+
+use CaptureHigherEd\LaravelJira\Api\Issues;
+use CaptureHigherEd\LaravelJira\Models\Attachments;
+use CaptureHigherEd\LaravelJira\Models\Comment;
+use CaptureHigherEd\LaravelJira\Models\Issue;
+use CaptureHigherEd\LaravelJira\Models\Search;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use PHPUnit\Framework\TestCase;
+
+class IssuesTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    public function test_index(): void
+    {
+        $response = $this->jsonResponse([
+            'issues' => [['id' => '1', 'key' => 'KEY-1', 'fields' => ['summary' => 'Test']]],
+        ]);
+        $client = $this->mockClientExpecting('GET', 'search', ['query' => ['jql' => 'project=TEST']], $response);
+        $api = new Issues($client);
+
+        $result = $api->index(['jql' => 'project=TEST']);
+
+        $this->assertInstanceOf(Search::class, $result);
+        $this->assertCount(1, $result->getIssues());
+    }
+
+    public function test_show(): void
+    {
+        $response = $this->jsonResponse(['id' => '10', 'key' => 'KEY-10', 'fields' => ['summary' => 'Issue']]);
+        $client = $this->mockClientExpecting('GET', 'issue/KEY-10', ['query' => []], $response);
+        $api = new Issues($client);
+
+        $result = $api->show('KEY-10');
+
+        $this->assertInstanceOf(Issue::class, $result);
+        $this->assertSame('KEY-10', $result->getKey());
+    }
+
+    public function test_create(): void
+    {
+        $response = $this->mockResponse(201, ['id' => '11', 'key' => 'KEY-11', 'fields' => []]);
+        $client = $this->mockClientExpecting('POST', 'issue', ['json' => ['fields' => ['summary' => 'New']]], $response);
+        $api = new Issues($client);
+
+        $result = $api->create(['fields' => ['summary' => 'New']]);
+
+        $this->assertInstanceOf(Issue::class, $result);
+        $this->assertSame('KEY-11', $result->getKey());
+    }
+
+    public function test_attach(): void
+    {
+        $response = $this->jsonResponse([
+            ['id' => '1', 'filename' => 'test.txt', 'mimeType' => 'text/plain', 'size' => 10, 'content' => '', 'self' => ''],
+        ]);
+        $multipart = [['name' => 'file', 'contents' => 'data', 'filename' => 'test.txt']];
+        $client = $this->mockClientExpecting('POST', 'issue/KEY-1/attachments', [
+            'multipart' => $multipart,
+            'headers' => ['Accept' => 'application/json', 'X-Atlassian-Token' => 'no-check'],
+        ], $response);
+        $api = new Issues($client);
+
+        $result = $api->attach('KEY-1', $multipart);
+
+        $this->assertInstanceOf(Attachments::class, $result);
+        $this->assertCount(1, $result->getAttachments());
+    }
+
+    public function test_comment(): void
+    {
+        $response = $this->jsonResponse([
+            'id' => '200',
+            'body' => [],
+            'created' => '2024-01-01T00:00:00.000+0000',
+            'updated' => '2024-01-01T00:00:00.000+0000',
+            'self' => 'https://example.com/comment/200',
+        ]);
+        $client = $this->mockClientExpecting('POST', 'issue/KEY-1/comment', ['json' => ['body' => []]], $response);
+        $api = new Issues($client);
+
+        $result = $api->comment('KEY-1', ['body' => []]);
+
+        $this->assertInstanceOf(Comment::class, $result);
+        $this->assertSame('200', $result->getId());
+    }
+
+    public function test_update(): void
+    {
+        $response = $this->mockResponse(200, ['id' => '10', 'key' => 'KEY-10', 'fields' => ['summary' => 'Updated']]);
+        $client = $this->mockClientExpecting('PUT', 'issue/KEY-10', ['json' => ['fields' => ['summary' => 'Updated']]], $response);
+        $api = new Issues($client);
+
+        $result = $api->update('KEY-10', ['fields' => ['summary' => 'Updated']]);
+
+        $this->assertInstanceOf(Issue::class, $result);
+    }
+
+    public function test_get_create_meta(): void
+    {
+        $meta = ['projects' => [['key' => 'TEST', 'issuetypes' => []]]];
+        $response = $this->jsonResponse($meta);
+        $client = $this->mockClientExpecting('GET', 'issue/createmeta', ['query' => []], $response);
+        $api = new Issues($client);
+
+        $result = $api->getCreateMeta();
+
+        $this->assertSame($meta, $result);
+    }
+
+    public function test_delete(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('DELETE', 'issue/KEY-1', [], $response);
+        $api = new Issues($client);
+
+        $result = $api->delete('KEY-1');
+
+        $this->assertSame([], $result);
+    }
+}

--- a/tests/Api/IssuesTest.php
+++ b/tests/Api/IssuesTest.php
@@ -24,8 +24,8 @@ class IssuesTest extends TestCase
 
         $result = $api->index(['jql' => 'project=TEST']);
 
-        $this->assertInstanceOf(Search::class, $result);
-        $this->assertCount(1, $result->getIssues());
+        $this->assertInstanceOf(Search::class, $result, 'Issues::index() should return a Search instance');
+        $this->assertCount(1, $result->getIssues(), 'Issues::index() search result should contain exactly 1 issue from the response');
     }
 
     public function test_show(): void
@@ -36,8 +36,8 @@ class IssuesTest extends TestCase
 
         $result = $api->show('KEY-10');
 
-        $this->assertInstanceOf(Issue::class, $result);
-        $this->assertSame('KEY-10', $result->getKey());
+        $this->assertInstanceOf(Issue::class, $result, 'Issues::show() should return an Issue instance');
+        $this->assertSame('KEY-10', $result->getKey(), 'Issues::show() should return the issue with the correct key');
     }
 
     public function test_create(): void
@@ -48,8 +48,8 @@ class IssuesTest extends TestCase
 
         $result = $api->create(['fields' => ['summary' => 'New']]);
 
-        $this->assertInstanceOf(Issue::class, $result);
-        $this->assertSame('KEY-11', $result->getKey());
+        $this->assertInstanceOf(Issue::class, $result, 'Issues::create() should return an Issue instance');
+        $this->assertSame('KEY-11', $result->getKey(), 'Issues::create() should return the newly created issue with the correct key');
     }
 
     public function test_attach(): void
@@ -66,8 +66,8 @@ class IssuesTest extends TestCase
 
         $result = $api->attach('KEY-1', $multipart);
 
-        $this->assertInstanceOf(Attachments::class, $result);
-        $this->assertCount(1, $result->getAttachments());
+        $this->assertInstanceOf(Attachments::class, $result, 'Issues::attach() should return an Attachments instance');
+        $this->assertCount(1, $result->getAttachments(), 'Issues::attach() should return the correct number of attachments from the response');
     }
 
     public function test_comment(): void
@@ -84,8 +84,8 @@ class IssuesTest extends TestCase
 
         $result = $api->comment('KEY-1', ['body' => []]);
 
-        $this->assertInstanceOf(Comment::class, $result);
-        $this->assertSame('200', $result->getId());
+        $this->assertInstanceOf(Comment::class, $result, 'Issues::comment() should return a Comment instance');
+        $this->assertSame('200', $result->getId(), 'Issues::comment() should return the comment with the correct ID from the response');
     }
 
     public function test_update(): void
@@ -96,7 +96,7 @@ class IssuesTest extends TestCase
 
         $result = $api->update('KEY-10', ['fields' => ['summary' => 'Updated']]);
 
-        $this->assertInstanceOf(Issue::class, $result);
+        $this->assertInstanceOf(Issue::class, $result, 'Issues::update() should return an Issue instance');
     }
 
     public function test_get_create_meta(): void
@@ -108,7 +108,7 @@ class IssuesTest extends TestCase
 
         $result = $api->getCreateMeta();
 
-        $this->assertSame($meta, $result);
+        $this->assertSame($meta, $result, 'Issues::getCreateMeta() should return the raw create metadata array from the API response');
     }
 
     public function test_delete(): void
@@ -119,6 +119,6 @@ class IssuesTest extends TestCase
 
         $result = $api->delete('KEY-1');
 
-        $this->assertSame([], $result);
+        $this->assertSame([], $result, 'Issues::delete() should return an empty array for a successful 204 No Content response');
     }
 }

--- a/tests/Api/IssuesTest.php
+++ b/tests/Api/IssuesTest.php
@@ -5,7 +5,9 @@ namespace CaptureHigherEd\LaravelJira\Tests\Api;
 use CaptureHigherEd\LaravelJira\Api\Issues;
 use CaptureHigherEd\LaravelJira\Models\Attachments;
 use CaptureHigherEd\LaravelJira\Models\Comment;
+use CaptureHigherEd\LaravelJira\Models\FieldMetas;
 use CaptureHigherEd\LaravelJira\Models\Issue;
+use CaptureHigherEd\LaravelJira\Models\IssueTypes;
 use CaptureHigherEd\LaravelJira\Models\Search;
 use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
 use PHPUnit\Framework\TestCase;
@@ -21,7 +23,7 @@ class IssuesTest extends TestCase
         $response = $this->jsonResponse([
             'issues' => [['id' => '1', 'key' => 'KEY-1', 'fields' => ['summary' => 'Test']]],
         ]);
-        $client = $this->mockClientExpecting('GET', 'search', ['query' => ['jql' => 'project=TEST']], $response);
+        $client = $this->mockClientExpecting('GET', 'search/jql', ['query' => ['jql' => 'project=TEST']], $response);
         $api = new Issues($client);
 
         $result = $api->index(['jql' => 'project=TEST']);
@@ -94,16 +96,42 @@ class IssuesTest extends TestCase
 
     public function test_update(): void
     {
-        $response = $this->mockResponse(200, ['id' => '10', 'key' => 'KEY-10', 'fields' => ['summary' => 'Updated']]);
+        $response = $this->noContentResponse();
         $client = $this->mockClientExpecting('PUT', 'issue/KEY-10', ['json' => ['fields' => ['summary' => 'Updated']]], $response);
         $api = new Issues($client);
 
         $result = $api->update('KEY-10', ['fields' => ['summary' => 'Updated']]);
 
-        $this->assertInstanceOf(Issue::class, $result, 'Issues::update() should return an Issue instance');
+        $this->assertSame([], $result, 'Issues::update() should return an empty array for a successful 204 No Content response');
     }
 
     // ── Metadata ──────────────────────────────────────────────────────────
+
+    public function test_get_create_meta_issue_types(): void
+    {
+        $response = $this->jsonResponse(['issueTypes' => [['id' => '10001', 'name' => 'Bug', 'description' => '', 'subtask' => false, 'iconUrl' => '', 'self' => '']]]);
+        $client = $this->mockClientExpecting('GET', 'issue/createmeta/TEST/issuetypes', ['query' => []], $response);
+        $api = new Issues($client);
+
+        $result = $api->getCreateMetaIssueTypes('TEST');
+
+        $this->assertInstanceOf(IssueTypes::class, $result, 'Issues::getCreateMetaIssueTypes() should return an IssueTypes instance');
+        $this->assertCount(1, $result->getIssueTypes(), 'Issues::getCreateMetaIssueTypes() should return exactly 1 issue type from the response');
+        $this->assertSame('10001', $result->getIssueTypes()[0]->getId(), 'Issues::getCreateMetaIssueTypes() should hydrate the issue type id correctly');
+    }
+
+    public function test_get_create_meta_fields(): void
+    {
+        $response = $this->jsonResponse(['fields' => [['fieldId' => 'summary', 'name' => 'Summary', 'required' => true, 'schema' => [], 'operations' => ['set'], 'allowedValues' => []]]]);
+        $client = $this->mockClientExpecting('GET', 'issue/createmeta/TEST/issuetypes/10001', ['query' => []], $response);
+        $api = new Issues($client);
+
+        $result = $api->getCreateMetaFields('TEST', '10001');
+
+        $this->assertInstanceOf(FieldMetas::class, $result, 'Issues::getCreateMetaFields() should return a FieldMetas instance');
+        $this->assertCount(1, $result->getFields(), 'Issues::getCreateMetaFields() should return exactly 1 field from the response');
+        $this->assertSame('summary', $result->getFields()[0]->getFieldId(), 'Issues::getCreateMetaFields() should hydrate the field id correctly');
+    }
 
     public function test_get_create_meta(): void
     {

--- a/tests/Api/UsersTest.php
+++ b/tests/Api/UsersTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Api;
+
+use CaptureHigherEd\LaravelJira\Api\Users;
+use CaptureHigherEd\LaravelJira\Models\Users as ModelsUsers;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use PHPUnit\Framework\TestCase;
+
+class UsersTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    public function test_index_with_default_max_results(): void
+    {
+        $response = $this->jsonResponse([
+            ['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => 'alice@example.com', 'active' => true],
+        ]);
+        $client = $this->mockClientExpecting('GET', 'users', ['query' => ['maxResults' => 1000]], $response);
+        $api = new Users($client);
+
+        $result = $api->index();
+
+        $this->assertInstanceOf(ModelsUsers::class, $result);
+        $this->assertCount(1, $result->getUsers());
+    }
+
+    public function test_index_with_custom_params(): void
+    {
+        $response = $this->jsonResponse([]);
+        $client = $this->mockClientExpecting('GET', 'users', ['query' => ['maxResults' => 50, 'startAt' => 100]], $response);
+        $api = new Users($client);
+
+        $result = $api->index(['maxResults' => 50, 'startAt' => 100]);
+
+        $this->assertInstanceOf(ModelsUsers::class, $result);
+    }
+}

--- a/tests/Api/UsersTest.php
+++ b/tests/Api/UsersTest.php
@@ -21,8 +21,8 @@ class UsersTest extends TestCase
 
         $result = $api->index();
 
-        $this->assertInstanceOf(ModelsUsers::class, $result);
-        $this->assertCount(1, $result->getUsers());
+        $this->assertInstanceOf(ModelsUsers::class, $result, 'Users::index() should return a Users model instance');
+        $this->assertCount(1, $result->getUsers(), 'Users::index() should return exactly 1 user from the response');
     }
 
     public function test_index_with_custom_params(): void
@@ -33,6 +33,6 @@ class UsersTest extends TestCase
 
         $result = $api->index(['maxResults' => 50, 'startAt' => 100]);
 
-        $this->assertInstanceOf(ModelsUsers::class, $result);
+        $this->assertInstanceOf(ModelsUsers::class, $result, 'Users::index() should return a Users model instance when called with custom query parameters');
     }
 }

--- a/tests/Concerns/MocksHttpResponses.php
+++ b/tests/Concerns/MocksHttpResponses.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Concerns;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+
+trait MocksHttpResponses
+{
+    /**
+     * @param  array<string, mixed>|string|null  $body
+     * @param  array<string, string>  $headers
+     */
+    protected function mockResponse(int $status, array|string|null $body = null, array $headers = []): Response
+    {
+        $bodyString = is_array($body) ? json_encode($body) : ($body ?? '');
+
+        if (is_array($body) && ! isset($headers['Content-Type'])) {
+            $headers['Content-Type'] = 'application/json';
+        }
+
+        return new Response($status, $headers, $bodyString);
+    }
+
+    /**
+     * @param  array<string, mixed>  $body
+     */
+    protected function jsonResponse(array $body, int $status = 200): Response
+    {
+        return $this->mockResponse($status, $body, ['Content-Type' => 'application/json']);
+    }
+
+    protected function noContentResponse(): Response
+    {
+        return new Response(204, [], '');
+    }
+
+    protected function plainErrorResponse(int $status, string $body): Response
+    {
+        return new Response($status, ['Content-Type' => 'text/plain'], $body);
+    }
+
+    /**
+     * @param  array<string, mixed>  $body
+     */
+    protected function jsonErrorResponse(int $status, array $body): Response
+    {
+        return new Response($status, ['Content-Type' => 'application/json'], json_encode($body));
+    }
+
+    protected function mockClient(ResponseInterface $response): ClientInterface
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('request')->willReturn($response);
+
+        return $client;
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    protected function mockClientExpecting(string $method, string $path, array $options, ResponseInterface $response): ClientInterface
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('request')
+            ->with($method, $path, $options)
+            ->willReturn($response);
+
+        return $client;
+    }
+}

--- a/tests/Concerns/MocksHttpResponses.php
+++ b/tests/Concerns/MocksHttpResponses.php
@@ -41,14 +41,6 @@ trait MocksHttpResponses
         return new Response($status, ['Content-Type' => 'text/plain'], $body);
     }
 
-    /**
-     * @param  array<string, mixed>  $body
-     */
-    protected function jsonErrorResponse(int $status, array $body): Response
-    {
-        return new Response($status, ['Content-Type' => 'application/json'], json_encode($body));
-    }
-
     protected function mockClient(ResponseInterface $response): ClientInterface
     {
         $client = $this->createMock(ClientInterface::class);

--- a/tests/Concerns/UsesTestbench.php
+++ b/tests/Concerns/UsesTestbench.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Concerns;
+
+use CaptureHigherEd\LaravelJira\Providers\IntegrationServiceProvider;
+
+trait UsesTestbench
+{
+    protected function getPackageProviders($app): array
+    {
+        return [IntegrationServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('jira.token', base64_encode('test@example.com:fake-token'));
+        $app['config']->set('jira.domain', 'https://test.atlassian.net');
+    }
+}

--- a/tests/Exception/CustomFieldDoesNotExistExceptionTest.php
+++ b/tests/Exception/CustomFieldDoesNotExistExceptionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Exception;
+
+use CaptureHigherEd\LaravelJira\Exception\CustomFieldDoesNotExistException;
+use PHPUnit\Framework\TestCase;
+
+class CustomFieldDoesNotExistExceptionTest extends TestCase
+{
+    public function test_message_includes_field_name(): void
+    {
+        $e = new CustomFieldDoesNotExistException('My Field');
+
+        $this->assertStringContainsString('My Field', $e->getMessage());
+    }
+
+    public function test_message_without_field_name(): void
+    {
+        $e = new CustomFieldDoesNotExistException;
+
+        $this->assertSame('Custom field does not exist.', $e->getMessage());
+    }
+
+    public function test_message_with_empty_string(): void
+    {
+        $e = new CustomFieldDoesNotExistException('');
+
+        $this->assertSame('Custom field does not exist.', $e->getMessage());
+    }
+}

--- a/tests/Exception/CustomFieldDoesNotExistExceptionTest.php
+++ b/tests/Exception/CustomFieldDoesNotExistExceptionTest.php
@@ -11,20 +11,20 @@ class CustomFieldDoesNotExistExceptionTest extends TestCase
     {
         $e = new CustomFieldDoesNotExistException('My Field');
 
-        $this->assertStringContainsString('My Field', $e->getMessage());
+        $this->assertStringContainsString('My Field', $e->getMessage(), 'Exception message should include the provided field name for easier diagnosis');
     }
 
     public function test_message_without_field_name(): void
     {
         $e = new CustomFieldDoesNotExistException;
 
-        $this->assertSame('Custom field does not exist.', $e->getMessage());
+        $this->assertSame('Custom field does not exist.', $e->getMessage(), 'Exception message should use the generic fallback when no field name is provided');
     }
 
     public function test_message_with_empty_string(): void
     {
         $e = new CustomFieldDoesNotExistException('');
 
-        $this->assertSame('Custom field does not exist.', $e->getMessage());
+        $this->assertSame('Custom field does not exist.', $e->getMessage(), 'Exception message should use the generic fallback when an empty string is provided as the field name');
     }
 }

--- a/tests/Exception/HttpClientExceptionTest.php
+++ b/tests/Exception/HttpClientExceptionTest.php
@@ -17,7 +17,7 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->jsonResponse(['message' => 'Bad input', 'status' => 400]);
         $e = new HttpClientException('Test', 400, $response);
 
-        $this->assertSame(['message' => 'Bad input', 'status' => 400], $e->getResponseBody());
+        $this->assertSame(['message' => 'Bad input', 'status' => 400], $e->getResponseBody(), 'Constructor should parse and store JSON response body as an array');
     }
 
     public function test_constructor_stores_non_json_body_as_message(): void
@@ -25,7 +25,7 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(400, 'Plain text error');
         $e = new HttpClientException('Test', 400, $response);
 
-        $this->assertSame(['message' => 'Plain text error'], $e->getResponseBody());
+        $this->assertSame(['message' => 'Plain text error'], $e->getResponseBody(), 'Constructor should wrap plain-text response body in a message array');
     }
 
     public function test_constructor_handles_empty_json_body(): void
@@ -33,7 +33,7 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->jsonResponse([], 200);
         $e = new HttpClientException('Test', 200, $response);
 
-        $this->assertSame([], $e->getResponseBody());
+        $this->assertSame([], $e->getResponseBody(), 'Constructor should store an empty array when the JSON response body is an empty object');
     }
 
     public function test_constructor_stores_response_code(): void
@@ -41,7 +41,7 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->jsonResponse([], 404);
         $e = new HttpClientException('Test', 404, $response);
 
-        $this->assertSame(404, $e->getResponseCode());
+        $this->assertSame(404, $e->getResponseCode(), 'Constructor should store the HTTP status code for retrieval via getResponseCode()');
     }
 
     public function test_constructor_stores_response(): void
@@ -49,7 +49,7 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->jsonResponse([], 200);
         $e = new HttpClientException('Test', 200, $response);
 
-        $this->assertSame($response, $e->getResponse());
+        $this->assertSame($response, $e->getResponse(), 'Constructor should store the original PSR response object for retrieval via getResponse()');
     }
 
     // ── Factory: badRequest ──────────────────────────────────────────────
@@ -59,8 +59,8 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->jsonErrorResponse(400, ['message' => 'Invalid field value']);
         $e = HttpClientException::badRequest($response);
 
-        $this->assertSame(400, $e->getCode());
-        $this->assertStringContainsString('Invalid field value', $e->getMessage());
+        $this->assertSame(400, $e->getCode(), 'badRequest() factory should set the exception code to 400');
+        $this->assertStringContainsString('Invalid field value', $e->getMessage(), 'badRequest() factory should include the JSON message field in the exception message');
     }
 
     public function test_bad_request_uses_raw_body_when_non_json(): void
@@ -68,7 +68,7 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(400, 'raw error body');
         $e = HttpClientException::badRequest($response);
 
-        $this->assertStringContainsString('raw error body', $e->getMessage());
+        $this->assertStringContainsString('raw error body', $e->getMessage(), 'badRequest() factory should include the raw body text when the response is not JSON');
     }
 
     public function test_bad_request_falls_back_when_no_message_key(): void
@@ -77,8 +77,8 @@ class HttpClientExceptionTest extends TestCase
         $e = HttpClientException::badRequest($response);
 
         // Falls back to raw JSON string since no 'message' key
-        $this->assertSame(400, $e->getCode());
-        $this->assertStringContainsString('parameters passed to the API', $e->getMessage());
+        $this->assertSame(400, $e->getCode(), 'badRequest() factory should set the exception code to 400 even when the message key is absent');
+        $this->assertStringContainsString('parameters passed to the API', $e->getMessage(), 'badRequest() factory should fall back to the generic bad request message when no message key exists in the JSON body');
     }
 
     // ── Factory: simple factories ────────────────────────────────────────
@@ -88,8 +88,8 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(401, '');
         $e = HttpClientException::unauthorized($response);
 
-        $this->assertSame(401, $e->getCode());
-        $this->assertStringContainsString('credentials', $e->getMessage());
+        $this->assertSame(401, $e->getCode(), 'unauthorized() factory should set the exception code to 401');
+        $this->assertStringContainsString('credentials', $e->getMessage(), 'unauthorized() factory should mention credentials in the exception message');
     }
 
     public function test_request_failed_message(): void
@@ -97,8 +97,8 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(402, '');
         $e = HttpClientException::requestFailed($response);
 
-        $this->assertSame(402, $e->getCode());
-        $this->assertStringContainsString('valid', $e->getMessage());
+        $this->assertSame(402, $e->getCode(), 'requestFailed() factory should set the exception code to 402');
+        $this->assertStringContainsString('valid', $e->getMessage(), 'requestFailed() factory should mention valid in the exception message');
     }
 
     public function test_not_found_message(): void
@@ -106,8 +106,8 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(404, '');
         $e = HttpClientException::notFound($response);
 
-        $this->assertSame(404, $e->getCode());
-        $this->assertStringContainsString('does not exist', $e->getMessage());
+        $this->assertSame(404, $e->getCode(), 'notFound() factory should set the exception code to 404');
+        $this->assertStringContainsString('does not exist', $e->getMessage(), 'notFound() factory should indicate the resource does not exist in the exception message');
     }
 
     public function test_conflict_message(): void
@@ -115,8 +115,8 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(409, '');
         $e = HttpClientException::conflict($response);
 
-        $this->assertSame(409, $e->getCode());
-        $this->assertStringContainsString('conflict', strtolower($e->getMessage()));
+        $this->assertSame(409, $e->getCode(), 'conflict() factory should set the exception code to 409');
+        $this->assertStringContainsString('conflict', strtolower($e->getMessage()), 'conflict() factory should mention conflict in the exception message');
     }
 
     public function test_payload_too_large_message(): void
@@ -124,8 +124,8 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(413, '');
         $e = HttpClientException::payloadTooLarge($response);
 
-        $this->assertSame(413, $e->getCode());
-        $this->assertStringContainsString('too large', strtolower($e->getMessage()));
+        $this->assertSame(413, $e->getCode(), 'payloadTooLarge() factory should set the exception code to 413');
+        $this->assertStringContainsString('too large', strtolower($e->getMessage()), 'payloadTooLarge() factory should indicate the payload is too large in the exception message');
     }
 
     // ── Factory: forbidden ───────────────────────────────────────────────
@@ -135,8 +135,8 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->jsonErrorResponse(403, ['Error' => 'Access denied']);
         $e = HttpClientException::forbidden($response);
 
-        $this->assertSame(403, $e->getCode());
-        $this->assertStringContainsString('Access denied', $e->getMessage());
+        $this->assertSame(403, $e->getCode(), 'forbidden() factory should set the exception code to 403');
+        $this->assertStringContainsString('Access denied', $e->getMessage(), 'forbidden() factory should extract and include the Error key from the JSON body');
     }
 
     public function test_forbidden_uses_raw_body_when_non_json(): void
@@ -144,7 +144,7 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(403, 'Forbidden response');
         $e = HttpClientException::forbidden($response);
 
-        $this->assertStringContainsString('Forbidden response', $e->getMessage());
+        $this->assertStringContainsString('Forbidden response', $e->getMessage(), 'forbidden() factory should include the raw body text when the response is not JSON');
     }
 
     // ── Factory: tooManyRequests ─────────────────────────────────────────
@@ -154,8 +154,8 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->mockResponse(429, '', ['Retry-After' => '30']);
         $e = HttpClientException::tooManyRequests($response);
 
-        $this->assertSame(429, $e->getCode());
-        $this->assertStringContainsString('30', $e->getMessage());
+        $this->assertSame(429, $e->getCode(), 'tooManyRequests() factory should set the exception code to 429');
+        $this->assertStringContainsString('30', $e->getMessage(), 'tooManyRequests() factory should include the Retry-After value in the exception message');
     }
 
     public function test_too_many_requests_without_retry_after(): void
@@ -163,8 +163,8 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(429, '');
         $e = HttpClientException::tooManyRequests($response);
 
-        $this->assertSame(429, $e->getCode());
-        $this->assertSame('Too many requests.', $e->getMessage());
+        $this->assertSame(429, $e->getCode(), 'tooManyRequests() factory should set the exception code to 429 when no Retry-After header is present');
+        $this->assertSame('Too many requests.', $e->getMessage(), 'tooManyRequests() factory should use the generic message when no Retry-After header is present');
     }
 
     // ── Factory: unprocessableEntity ────────────────────────────────────
@@ -174,9 +174,9 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->jsonErrorResponse(422, ['errorMessages' => ['Field A is required', 'Field B is invalid']]);
         $e = HttpClientException::unprocessableEntity($response);
 
-        $this->assertSame(422, $e->getCode());
-        $this->assertStringContainsString('Field A is required', $e->getMessage());
-        $this->assertStringContainsString('Field B is invalid', $e->getMessage());
+        $this->assertSame(422, $e->getCode(), 'unprocessableEntity() factory should set the exception code to 422');
+        $this->assertStringContainsString('Field A is required', $e->getMessage(), 'unprocessableEntity() factory should include the first errorMessages entry in the exception message');
+        $this->assertStringContainsString('Field B is invalid', $e->getMessage(), 'unprocessableEntity() factory should include all errorMessages entries in the exception message');
     }
 
     public function test_unprocessable_entity_non_json_fallback(): void
@@ -184,8 +184,8 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(422, 'Validation failed');
         $e = HttpClientException::unprocessableEntity($response);
 
-        $this->assertSame(422, $e->getCode());
-        $this->assertStringContainsString('Validation failed', $e->getMessage());
+        $this->assertSame(422, $e->getCode(), 'unprocessableEntity() factory should set the exception code to 422 for non-JSON responses');
+        $this->assertStringContainsString('Validation failed', $e->getMessage(), 'unprocessableEntity() factory should include the raw body text when the response is not JSON');
     }
 
     // ── Factory: serverError ─────────────────────────────────────────────
@@ -196,8 +196,8 @@ class HttpClientExceptionTest extends TestCase
             $response = $this->plainErrorResponse($status, '');
             $e = HttpClientException::serverError($response);
 
-            $this->assertSame($status, $e->getCode());
-            $this->assertStringContainsString((string) $status, $e->getMessage());
+            $this->assertSame($status, $e->getCode(), "serverError() factory should set the exception code to $status");
+            $this->assertStringContainsString((string) $status, $e->getMessage(), "serverError() factory should include the HTTP status code $status in the exception message");
         }
     }
 
@@ -208,7 +208,7 @@ class HttpClientExceptionTest extends TestCase
         $response = $this->plainErrorResponse(418, '');
         $e = HttpClientException::unknown($response);
 
-        $this->assertSame(418, $e->getCode());
-        $this->assertSame('Unknown Error', $e->getMessage());
+        $this->assertSame(418, $e->getCode(), 'unknown() factory should preserve the HTTP status code from the response');
+        $this->assertSame('Unknown Error', $e->getMessage(), 'unknown() factory should use the generic "Unknown Error" message');
     }
 }

--- a/tests/Exception/HttpClientExceptionTest.php
+++ b/tests/Exception/HttpClientExceptionTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Exception;
+
+use CaptureHigherEd\LaravelJira\Exception\HttpClientException;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use PHPUnit\Framework\TestCase;
+
+class HttpClientExceptionTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    // ── Constructor branching ────────────────────────────────────────────
+
+    public function test_constructor_parses_json_body(): void
+    {
+        $response = $this->jsonResponse(['message' => 'Bad input', 'status' => 400]);
+        $e = new HttpClientException('Test', 400, $response);
+
+        $this->assertSame(['message' => 'Bad input', 'status' => 400], $e->getResponseBody());
+    }
+
+    public function test_constructor_stores_non_json_body_as_message(): void
+    {
+        $response = $this->plainErrorResponse(400, 'Plain text error');
+        $e = new HttpClientException('Test', 400, $response);
+
+        $this->assertSame(['message' => 'Plain text error'], $e->getResponseBody());
+    }
+
+    public function test_constructor_handles_empty_json_body(): void
+    {
+        $response = $this->jsonResponse([], 200);
+        $e = new HttpClientException('Test', 200, $response);
+
+        $this->assertSame([], $e->getResponseBody());
+    }
+
+    public function test_constructor_stores_response_code(): void
+    {
+        $response = $this->jsonResponse([], 404);
+        $e = new HttpClientException('Test', 404, $response);
+
+        $this->assertSame(404, $e->getResponseCode());
+    }
+
+    public function test_constructor_stores_response(): void
+    {
+        $response = $this->jsonResponse([], 200);
+        $e = new HttpClientException('Test', 200, $response);
+
+        $this->assertSame($response, $e->getResponse());
+    }
+
+    // ── Factory: badRequest ──────────────────────────────────────────────
+
+    public function test_bad_request_extracts_json_message(): void
+    {
+        $response = $this->jsonErrorResponse(400, ['message' => 'Invalid field value']);
+        $e = HttpClientException::badRequest($response);
+
+        $this->assertSame(400, $e->getCode());
+        $this->assertStringContainsString('Invalid field value', $e->getMessage());
+    }
+
+    public function test_bad_request_uses_raw_body_when_non_json(): void
+    {
+        $response = $this->plainErrorResponse(400, 'raw error body');
+        $e = HttpClientException::badRequest($response);
+
+        $this->assertStringContainsString('raw error body', $e->getMessage());
+    }
+
+    public function test_bad_request_falls_back_when_no_message_key(): void
+    {
+        $response = $this->jsonErrorResponse(400, ['errorMessages' => ['Something failed']]);
+        $e = HttpClientException::badRequest($response);
+
+        // Falls back to raw JSON string since no 'message' key
+        $this->assertSame(400, $e->getCode());
+        $this->assertStringContainsString('parameters passed to the API', $e->getMessage());
+    }
+
+    // ── Factory: simple factories ────────────────────────────────────────
+
+    public function test_unauthorized_message(): void
+    {
+        $response = $this->plainErrorResponse(401, '');
+        $e = HttpClientException::unauthorized($response);
+
+        $this->assertSame(401, $e->getCode());
+        $this->assertStringContainsString('credentials', $e->getMessage());
+    }
+
+    public function test_request_failed_message(): void
+    {
+        $response = $this->plainErrorResponse(402, '');
+        $e = HttpClientException::requestFailed($response);
+
+        $this->assertSame(402, $e->getCode());
+        $this->assertStringContainsString('valid', $e->getMessage());
+    }
+
+    public function test_not_found_message(): void
+    {
+        $response = $this->plainErrorResponse(404, '');
+        $e = HttpClientException::notFound($response);
+
+        $this->assertSame(404, $e->getCode());
+        $this->assertStringContainsString('does not exist', $e->getMessage());
+    }
+
+    public function test_conflict_message(): void
+    {
+        $response = $this->plainErrorResponse(409, '');
+        $e = HttpClientException::conflict($response);
+
+        $this->assertSame(409, $e->getCode());
+        $this->assertStringContainsString('conflict', strtolower($e->getMessage()));
+    }
+
+    public function test_payload_too_large_message(): void
+    {
+        $response = $this->plainErrorResponse(413, '');
+        $e = HttpClientException::payloadTooLarge($response);
+
+        $this->assertSame(413, $e->getCode());
+        $this->assertStringContainsString('too large', strtolower($e->getMessage()));
+    }
+
+    // ── Factory: forbidden ───────────────────────────────────────────────
+
+    public function test_forbidden_extracts_json_error_key(): void
+    {
+        $response = $this->jsonErrorResponse(403, ['Error' => 'Access denied']);
+        $e = HttpClientException::forbidden($response);
+
+        $this->assertSame(403, $e->getCode());
+        $this->assertStringContainsString('Access denied', $e->getMessage());
+    }
+
+    public function test_forbidden_uses_raw_body_when_non_json(): void
+    {
+        $response = $this->plainErrorResponse(403, 'Forbidden response');
+        $e = HttpClientException::forbidden($response);
+
+        $this->assertStringContainsString('Forbidden response', $e->getMessage());
+    }
+
+    // ── Factory: tooManyRequests ─────────────────────────────────────────
+
+    public function test_too_many_requests_with_retry_after_header(): void
+    {
+        $response = $this->mockResponse(429, '', ['Retry-After' => '30']);
+        $e = HttpClientException::tooManyRequests($response);
+
+        $this->assertSame(429, $e->getCode());
+        $this->assertStringContainsString('30', $e->getMessage());
+    }
+
+    public function test_too_many_requests_without_retry_after(): void
+    {
+        $response = $this->plainErrorResponse(429, '');
+        $e = HttpClientException::tooManyRequests($response);
+
+        $this->assertSame(429, $e->getCode());
+        $this->assertSame('Too many requests.', $e->getMessage());
+    }
+
+    // ── Factory: unprocessableEntity ────────────────────────────────────
+
+    public function test_unprocessable_entity_extracts_error_messages(): void
+    {
+        $response = $this->jsonErrorResponse(422, ['errorMessages' => ['Field A is required', 'Field B is invalid']]);
+        $e = HttpClientException::unprocessableEntity($response);
+
+        $this->assertSame(422, $e->getCode());
+        $this->assertStringContainsString('Field A is required', $e->getMessage());
+        $this->assertStringContainsString('Field B is invalid', $e->getMessage());
+    }
+
+    public function test_unprocessable_entity_non_json_fallback(): void
+    {
+        $response = $this->plainErrorResponse(422, 'Validation failed');
+        $e = HttpClientException::unprocessableEntity($response);
+
+        $this->assertSame(422, $e->getCode());
+        $this->assertStringContainsString('Validation failed', $e->getMessage());
+    }
+
+    // ── Factory: serverError ─────────────────────────────────────────────
+
+    public function test_server_error_includes_status_code(): void
+    {
+        foreach ([500, 502, 503] as $status) {
+            $response = $this->plainErrorResponse($status, '');
+            $e = HttpClientException::serverError($response);
+
+            $this->assertSame($status, $e->getCode());
+            $this->assertStringContainsString((string) $status, $e->getMessage());
+        }
+    }
+
+    // ── Factory: unknown ─────────────────────────────────────────────────
+
+    public function test_unknown_error(): void
+    {
+        $response = $this->plainErrorResponse(418, '');
+        $e = HttpClientException::unknown($response);
+
+        $this->assertSame(418, $e->getCode());
+        $this->assertSame('Unknown Error', $e->getMessage());
+    }
+}

--- a/tests/Exception/HttpClientExceptionTest.php
+++ b/tests/Exception/HttpClientExceptionTest.php
@@ -56,7 +56,7 @@ class HttpClientExceptionTest extends TestCase
 
     public function test_bad_request_extracts_json_message(): void
     {
-        $response = $this->jsonErrorResponse(400, ['message' => 'Invalid field value']);
+        $response = $this->jsonResponse(['message' => 'Invalid field value'], 400);
         $e = HttpClientException::badRequest($response);
 
         $this->assertSame(400, $e->getCode(), 'badRequest() factory should set the exception code to 400');
@@ -73,7 +73,7 @@ class HttpClientExceptionTest extends TestCase
 
     public function test_bad_request_falls_back_when_no_message_key(): void
     {
-        $response = $this->jsonErrorResponse(400, ['errorMessages' => ['Something failed']]);
+        $response = $this->jsonResponse(['errorMessages' => ['Something failed']], 400);
         $e = HttpClientException::badRequest($response);
 
         // Falls back to raw JSON string since no 'message' key
@@ -83,56 +83,34 @@ class HttpClientExceptionTest extends TestCase
 
     // ── Factory: simple factories ────────────────────────────────────────
 
-    public function test_unauthorized_message(): void
+    /** @dataProvider simpleFactoryProvider */
+    public function test_simple_factory(string $method, int $status, string $needle, bool $lowercase): void
     {
-        $response = $this->plainErrorResponse(401, '');
-        $e = HttpClientException::unauthorized($response);
+        $response = $this->plainErrorResponse($status, '');
+        $e = HttpClientException::$method($response);
+        $message = $lowercase ? strtolower($e->getMessage()) : $e->getMessage();
 
-        $this->assertSame(401, $e->getCode(), 'unauthorized() factory should set the exception code to 401');
-        $this->assertStringContainsString('credentials', $e->getMessage(), 'unauthorized() factory should mention credentials in the exception message');
+        $this->assertSame($status, $e->getCode(), "$method() factory should set the exception code to $status");
+        $this->assertStringContainsString($needle, $message, "$method() factory should include '$needle' in the exception message");
     }
 
-    public function test_request_failed_message(): void
+    /** @return array<string, array{string, int, string, bool}> */
+    public static function simpleFactoryProvider(): array
     {
-        $response = $this->plainErrorResponse(402, '');
-        $e = HttpClientException::requestFailed($response);
-
-        $this->assertSame(402, $e->getCode(), 'requestFailed() factory should set the exception code to 402');
-        $this->assertStringContainsString('valid', $e->getMessage(), 'requestFailed() factory should mention valid in the exception message');
-    }
-
-    public function test_not_found_message(): void
-    {
-        $response = $this->plainErrorResponse(404, '');
-        $e = HttpClientException::notFound($response);
-
-        $this->assertSame(404, $e->getCode(), 'notFound() factory should set the exception code to 404');
-        $this->assertStringContainsString('does not exist', $e->getMessage(), 'notFound() factory should indicate the resource does not exist in the exception message');
-    }
-
-    public function test_conflict_message(): void
-    {
-        $response = $this->plainErrorResponse(409, '');
-        $e = HttpClientException::conflict($response);
-
-        $this->assertSame(409, $e->getCode(), 'conflict() factory should set the exception code to 409');
-        $this->assertStringContainsString('conflict', strtolower($e->getMessage()), 'conflict() factory should mention conflict in the exception message');
-    }
-
-    public function test_payload_too_large_message(): void
-    {
-        $response = $this->plainErrorResponse(413, '');
-        $e = HttpClientException::payloadTooLarge($response);
-
-        $this->assertSame(413, $e->getCode(), 'payloadTooLarge() factory should set the exception code to 413');
-        $this->assertStringContainsString('too large', strtolower($e->getMessage()), 'payloadTooLarge() factory should indicate the payload is too large in the exception message');
+        return [
+            'unauthorized' => ['unauthorized',    401, 'credentials',  false],
+            'requestFailed' => ['requestFailed',   402, 'valid',        false],
+            'notFound' => ['notFound',         404, 'does not exist', false],
+            'conflict' => ['conflict',         409, 'conflict',    true],
+            'payloadTooLarge' => ['payloadTooLarge',  413, 'too large',   true],
+        ];
     }
 
     // ── Factory: forbidden ───────────────────────────────────────────────
 
     public function test_forbidden_extracts_json_error_key(): void
     {
-        $response = $this->jsonErrorResponse(403, ['Error' => 'Access denied']);
+        $response = $this->jsonResponse(['Error' => 'Access denied'], 403);
         $e = HttpClientException::forbidden($response);
 
         $this->assertSame(403, $e->getCode(), 'forbidden() factory should set the exception code to 403');
@@ -171,7 +149,7 @@ class HttpClientExceptionTest extends TestCase
 
     public function test_unprocessable_entity_extracts_error_messages(): void
     {
-        $response = $this->jsonErrorResponse(422, ['errorMessages' => ['Field A is required', 'Field B is invalid']]);
+        $response = $this->jsonResponse(['errorMessages' => ['Field A is required', 'Field B is invalid']], 422);
         $e = HttpClientException::unprocessableEntity($response);
 
         $this->assertSame(422, $e->getCode(), 'unprocessableEntity() factory should set the exception code to 422');

--- a/tests/HttpClientConnectorTest.php
+++ b/tests/HttpClientConnectorTest.php
@@ -21,7 +21,7 @@ class HttpClientConnectorTest extends TestCase
     {
         $client = $this->connector->createClient();
 
-        $this->assertInstanceOf(Client::class, $client);
+        $this->assertInstanceOf(Client::class, $client, 'createClient() should return a GuzzleHttp\\Client instance');
     }
 
     public function test_create_client_sets_base_uri(): void
@@ -30,7 +30,8 @@ class HttpClientConnectorTest extends TestCase
 
         $this->assertSame(
             'https://test.atlassian.net/rest/api/3/',
-            (string) $client->getConfig('base_uri')
+            (string) $client->getConfig('base_uri'),
+            'Guzzle client base_uri should match the configured endpoint'
         );
     }
 
@@ -39,13 +40,13 @@ class HttpClientConnectorTest extends TestCase
         $client = $this->connector->createClient();
         $headers = $client->getConfig('headers');
 
-        $this->assertSame('Basic dGVzdEBleGFtcGxlLmNvbTpmYWtlLXRva2Vu', $headers['Authorization']);
+        $this->assertSame('Basic dGVzdEBleGFtcGxlLmNvbTpmYWtlLXRva2Vu', $headers['Authorization'], 'Authorization header should be a Basic token using the configured API key');
     }
 
     public function test_create_client_disables_http_errors(): void
     {
         $client = $this->connector->createClient();
 
-        $this->assertFalse($client->getConfig('http_errors'));
+        $this->assertFalse($client->getConfig('http_errors'), 'Guzzle http_errors option should be disabled so errors are handled manually');
     }
 }

--- a/tests/HttpClientConnectorTest.php
+++ b/tests/HttpClientConnectorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests;
+
+use CaptureHigherEd\LaravelJira\HttpClientConnector;
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class HttpClientConnectorTest extends TestCase
+{
+    private HttpClientConnector $connector;
+
+    protected function setUp(): void
+    {
+        $this->connector = (new HttpClientConnector)
+            ->setEndpoint('https://test.atlassian.net/rest/api/3/')
+            ->setApiKey('dGVzdEBleGFtcGxlLmNvbTpmYWtlLXRva2Vu');
+    }
+
+    public function test_create_client_returns_guzzle_client(): void
+    {
+        $client = $this->connector->createClient();
+
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
+    public function test_create_client_sets_base_uri(): void
+    {
+        $client = $this->connector->createClient();
+
+        $this->assertSame(
+            'https://test.atlassian.net/rest/api/3/',
+            (string) $client->getConfig('base_uri')
+        );
+    }
+
+    public function test_create_client_sets_authorization_header(): void
+    {
+        $client = $this->connector->createClient();
+        $headers = $client->getConfig('headers');
+
+        $this->assertSame('Basic dGVzdEBleGFtcGxlLmNvbTpmYWtlLXRva2Vu', $headers['Authorization']);
+    }
+
+    public function test_create_client_disables_http_errors(): void
+    {
+        $client = $this->connector->createClient();
+
+        $this->assertFalse($client->getConfig('http_errors'));
+    }
+}

--- a/tests/JiraTest.php
+++ b/tests/JiraTest.php
@@ -2,6 +2,9 @@
 
 namespace CaptureHigherEd\LaravelJira\Tests;
 
+use CaptureHigherEd\LaravelJira\Api\Fields;
+use CaptureHigherEd\LaravelJira\Api\Issues;
+use CaptureHigherEd\LaravelJira\Api\Users;
 use CaptureHigherEd\LaravelJira\Jira;
 use CaptureHigherEd\LaravelJira\Providers\IntegrationServiceProvider;
 use Orchestra\Testbench\TestCase;
@@ -24,5 +27,35 @@ class JiraTest extends TestCase
         $jira = $this->app->make(Jira::class);
 
         $this->assertInstanceOf(Jira::class, $jira);
+    }
+
+    public function test_jira_service_returns_null_when_token_missing(): void
+    {
+        $this->app['config']->set('jira.token', null);
+
+        $jira = $this->app->make(Jira::class);
+
+        $this->assertNull($jira);
+    }
+
+    public function test_jira_exposes_issues_api(): void
+    {
+        $jira = $this->app->make(Jira::class);
+
+        $this->assertInstanceOf(Issues::class, $jira->issues());
+    }
+
+    public function test_jira_exposes_fields_api(): void
+    {
+        $jira = $this->app->make(Jira::class);
+
+        $this->assertInstanceOf(Fields::class, $jira->fields());
+    }
+
+    public function test_jira_exposes_users_api(): void
+    {
+        $jira = $this->app->make(Jira::class);
+
+        $this->assertInstanceOf(Users::class, $jira->users());
     }
 }

--- a/tests/JiraTest.php
+++ b/tests/JiraTest.php
@@ -26,7 +26,7 @@ class JiraTest extends TestCase
     {
         $jira = $this->app->make(Jira::class);
 
-        $this->assertInstanceOf(Jira::class, $jira);
+        $this->assertInstanceOf(Jira::class, $jira, 'Jira service should resolve to a Jira instance when credentials are present');
     }
 
     public function test_jira_service_returns_null_when_token_missing(): void
@@ -35,27 +35,27 @@ class JiraTest extends TestCase
 
         $jira = $this->app->make(Jira::class);
 
-        $this->assertNull($jira);
+        $this->assertNull($jira, 'Jira service should return null when the API token is not configured');
     }
 
     public function test_jira_exposes_issues_api(): void
     {
         $jira = $this->app->make(Jira::class);
 
-        $this->assertInstanceOf(Issues::class, $jira->issues());
+        $this->assertInstanceOf(Issues::class, $jira->issues(), 'Jira::issues() should return an Issues API instance');
     }
 
     public function test_jira_exposes_fields_api(): void
     {
         $jira = $this->app->make(Jira::class);
 
-        $this->assertInstanceOf(Fields::class, $jira->fields());
+        $this->assertInstanceOf(Fields::class, $jira->fields(), 'Jira::fields() should return a Fields API instance');
     }
 
     public function test_jira_exposes_users_api(): void
     {
         $jira = $this->app->make(Jira::class);
 
-        $this->assertInstanceOf(Users::class, $jira->users());
+        $this->assertInstanceOf(Users::class, $jira->users(), 'Jira::users() should return a Users API instance');
     }
 }

--- a/tests/JiraTest.php
+++ b/tests/JiraTest.php
@@ -6,21 +6,14 @@ use CaptureHigherEd\LaravelJira\Api\Fields;
 use CaptureHigherEd\LaravelJira\Api\Issues;
 use CaptureHigherEd\LaravelJira\Api\Users;
 use CaptureHigherEd\LaravelJira\Jira;
-use CaptureHigherEd\LaravelJira\Providers\IntegrationServiceProvider;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\UsesTestbench;
 use Orchestra\Testbench\TestCase;
 
 class JiraTest extends TestCase
 {
-    protected function getPackageProviders($app): array
-    {
-        return [IntegrationServiceProvider::class];
-    }
+    use UsesTestbench;
 
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('jira.token', base64_encode('test@example.com:fake-token'));
-        $app['config']->set('jira.domain', 'https://test.atlassian.net');
-    }
+    // ── Service resolution ────────────────────────────────────────────────
 
     public function test_jira_service_can_be_resolved(): void
     {
@@ -37,6 +30,8 @@ class JiraTest extends TestCase
 
         $this->assertNull($jira, 'Jira service should return null when the API token is not configured');
     }
+
+    // ── API accessors ─────────────────────────────────────────────────────
 
     public function test_jira_exposes_issues_api(): void
     {

--- a/tests/JiraTest.php
+++ b/tests/JiraTest.php
@@ -1,34 +1,28 @@
 <?php
 
-namespace tests;
+namespace CaptureHigherEd\LaravelJira\Tests;
 
-use Tests\TestCase;
 use CaptureHigherEd\LaravelJira\Jira;
+use CaptureHigherEd\LaravelJira\Providers\IntegrationServiceProvider;
+use Orchestra\Testbench\TestCase;
 
-/**
- * @group Integrations
- * @group skip
- */
 class JiraTest extends TestCase
 {
-    private $jiraService;
-
-    protected function setUp(): void
+    protected function getPackageProviders($app): array
     {
-        $this->jiraService = app(Jira::class);
-
-        $this->assertNotNull($this->jiraService);
-
-        parent::setUp();
+        return [IntegrationServiceProvider::class];
     }
 
-    public function test_get_issues()
+    protected function defineEnvironment($app): void
     {
-        $issues = $this->jiraService->issues()->index();
-        $this->assertNotNull($issues);
+        $app['config']->set('jira.token', base64_encode('test@example.com:fake-token'));
+        $app['config']->set('jira.domain', 'https://test.atlassian.net');
+    }
 
-        $issueKey = $issues->getIssues()[0]->getKey();
-        $issue = $this->jiraService->issues()->show($issueKey);
-        $this->assertNotNull($issue);
+    public function test_jira_service_can_be_resolved(): void
+    {
+        $jira = $this->app->make(Jira::class);
+
+        $this->assertInstanceOf(Jira::class, $jira);
     }
 }

--- a/tests/Models/AttachmentTest.php
+++ b/tests/Models/AttachmentTest.php
@@ -3,6 +3,7 @@
 namespace CaptureHigherEd\LaravelJira\Tests\Models;
 
 use CaptureHigherEd\LaravelJira\Models\Attachment;
+use CaptureHigherEd\LaravelJira\Models\User;
 use PHPUnit\Framework\TestCase;
 
 class AttachmentTest extends TestCase
@@ -11,6 +12,17 @@ class AttachmentTest extends TestCase
 
     public function test_make_roundtrip(): void
     {
+        $authorData = [
+            'accountId' => 'abc123',
+            'displayName' => 'Jane Smith',
+            'emailAddress' => 'jane@example.com',
+            'active' => true,
+            'self' => '',
+            'accountType' => '',
+            'timeZone' => '',
+            'locale' => '',
+            'avatarUrls' => [],
+        ];
         $data = [
             'id' => '12345',
             'filename' => 'screenshot.png',
@@ -18,6 +30,9 @@ class AttachmentTest extends TestCase
             'size' => 98765,
             'content' => 'https://example.atlassian.net/content/screenshot.png',
             'self' => 'https://example.atlassian.net/rest/api/3/attachment/12345',
+            'author' => $authorData,
+            'created' => '2024-01-01T00:00:00.000+0000',
+            'thumbnail' => 'https://example.atlassian.net/thumbnail/12345',
         ];
 
         $attachment = Attachment::make($data);
@@ -35,6 +50,9 @@ class AttachmentTest extends TestCase
         $this->assertSame(0, $attachment->getSize(), 'Attachment size should default to 0 when not provided');
         $this->assertSame('', $attachment->getContent(), 'Attachment content URL should default to an empty string when not provided');
         $this->assertSame('', $attachment->getSelf(), 'Attachment self URL should default to an empty string when not provided');
+        $this->assertNull($attachment->getAuthor(), 'Attachment author should default to null when not provided');
+        $this->assertSame('', $attachment->getCreated(), 'Attachment created timestamp should default to an empty string when not provided');
+        $this->assertSame('', $attachment->getThumbnail(), 'Attachment thumbnail URL should default to an empty string when not provided');
     }
 
     // ── Type casting ──────────────────────────────────────────────────────
@@ -45,5 +63,25 @@ class AttachmentTest extends TestCase
 
         $this->assertSame(12345, $attachment->getSize(), 'Attachment size should be cast to integer even when provided as a string');
         $this->assertIsInt($attachment->getSize(), 'Attachment size should be stored and returned as an integer');
+    }
+
+    // ── Author hydration ──────────────────────────────────────────────────
+
+    public function test_author_is_hydrated_as_user(): void
+    {
+        $attachment = Attachment::make([
+            'id' => '1',
+            'author' => ['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => 'alice@example.com', 'active' => true],
+        ]);
+
+        $this->assertInstanceOf(User::class, $attachment->getAuthor(), 'Attachment author should be hydrated as a User instance');
+        $this->assertSame('u1', $attachment->getAuthor()?->getKey(), 'Attachment author accountId should be hydrated correctly');
+    }
+
+    public function test_make_without_author_returns_null(): void
+    {
+        $attachment = Attachment::make(['id' => '1']);
+
+        $this->assertNull($attachment->getAuthor(), 'Attachment author should be null when not present in the response data');
     }
 }

--- a/tests/Models/AttachmentTest.php
+++ b/tests/Models/AttachmentTest.php
@@ -20,26 +20,26 @@ class AttachmentTest extends TestCase
 
         $attachment = Attachment::make($data);
 
-        $this->assertSame($data, $attachment->toArray());
+        $this->assertSame($data, $attachment->toArray(), 'Attachment::toArray() should return the same data that was passed to make()');
     }
 
     public function test_make_with_empty_data(): void
     {
         $attachment = Attachment::make();
 
-        $this->assertSame('', $attachment->getId());
-        $this->assertSame('', $attachment->getFilename());
-        $this->assertSame('', $attachment->getMimeType());
-        $this->assertSame(0, $attachment->getSize());
-        $this->assertSame('', $attachment->getContent());
-        $this->assertSame('', $attachment->getSelf());
+        $this->assertSame('', $attachment->getId(), 'Attachment ID should default to an empty string when not provided');
+        $this->assertSame('', $attachment->getFilename(), 'Attachment filename should default to an empty string when not provided');
+        $this->assertSame('', $attachment->getMimeType(), 'Attachment MIME type should default to an empty string when not provided');
+        $this->assertSame(0, $attachment->getSize(), 'Attachment size should default to 0 when not provided');
+        $this->assertSame('', $attachment->getContent(), 'Attachment content URL should default to an empty string when not provided');
+        $this->assertSame('', $attachment->getSelf(), 'Attachment self URL should default to an empty string when not provided');
     }
 
     public function test_size_cast_to_int(): void
     {
         $attachment = Attachment::make(['size' => '12345']);
 
-        $this->assertSame(12345, $attachment->getSize());
-        $this->assertIsInt($attachment->getSize());
+        $this->assertSame(12345, $attachment->getSize(), 'Attachment size should be cast to integer even when provided as a string');
+        $this->assertIsInt($attachment->getSize(), 'Attachment size should be stored and returned as an integer');
     }
 }

--- a/tests/Models/AttachmentTest.php
+++ b/tests/Models/AttachmentTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 class AttachmentTest extends TestCase
 {
+    // ── make & toArray ────────────────────────────────────────────────────
+
     public function test_make_roundtrip(): void
     {
         $data = [
@@ -34,6 +36,8 @@ class AttachmentTest extends TestCase
         $this->assertSame('', $attachment->getContent(), 'Attachment content URL should default to an empty string when not provided');
         $this->assertSame('', $attachment->getSelf(), 'Attachment self URL should default to an empty string when not provided');
     }
+
+    // ── Type casting ──────────────────────────────────────────────────────
 
     public function test_size_cast_to_int(): void
     {

--- a/tests/Models/AttachmentTest.php
+++ b/tests/Models/AttachmentTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Attachment;
+use PHPUnit\Framework\TestCase;
+
+class AttachmentTest extends TestCase
+{
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => '12345',
+            'filename' => 'screenshot.png',
+            'mimeType' => 'image/png',
+            'size' => 98765,
+            'content' => 'https://example.atlassian.net/content/screenshot.png',
+            'self' => 'https://example.atlassian.net/rest/api/3/attachment/12345',
+        ];
+
+        $attachment = Attachment::make($data);
+
+        $this->assertSame($data, $attachment->toArray());
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $attachment = Attachment::make();
+
+        $this->assertSame('', $attachment->getId());
+        $this->assertSame('', $attachment->getFilename());
+        $this->assertSame('', $attachment->getMimeType());
+        $this->assertSame(0, $attachment->getSize());
+        $this->assertSame('', $attachment->getContent());
+        $this->assertSame('', $attachment->getSelf());
+    }
+
+    public function test_size_cast_to_int(): void
+    {
+        $attachment = Attachment::make(['size' => '12345']);
+
+        $this->assertSame(12345, $attachment->getSize());
+        $this->assertIsInt($attachment->getSize());
+    }
+}

--- a/tests/Models/AttachmentsTest.php
+++ b/tests/Models/AttachmentsTest.php
@@ -18,6 +18,9 @@ class AttachmentsTest extends TestCase
                 'size' => 100,
                 'content' => 'https://example.com/a.png',
                 'self' => 'https://example.com/attachment/1',
+                'author' => null,
+                'created' => '2024-01-01T00:00:00.000+0000',
+                'thumbnail' => '',
             ],
             [
                 'id' => '2',
@@ -26,6 +29,9 @@ class AttachmentsTest extends TestCase
                 'size' => 200,
                 'content' => 'https://example.com/b.pdf',
                 'self' => 'https://example.com/attachment/2',
+                'author' => null,
+                'created' => '2024-01-02T00:00:00.000+0000',
+                'thumbnail' => '',
             ],
         ];
 

--- a/tests/Models/AttachmentsTest.php
+++ b/tests/Models/AttachmentsTest.php
@@ -31,16 +31,16 @@ class AttachmentsTest extends TestCase
 
         $attachments = Attachments::make($data);
 
-        $this->assertCount(2, $attachments->getAttachments());
-        $this->assertContainsOnlyInstancesOf(Attachment::class, $attachments->getAttachments());
-        $this->assertSame($data, $attachments->toArray());
+        $this->assertCount(2, $attachments->getAttachments(), 'Attachments collection should contain exactly 2 items matching the input array');
+        $this->assertContainsOnlyInstancesOf(Attachment::class, $attachments->getAttachments(), 'All items in the Attachments collection should be hydrated as Attachment instances');
+        $this->assertSame($data, $attachments->toArray(), 'Attachments::toArray() should return the same data that was passed to make()');
     }
 
     public function test_make_with_empty_array(): void
     {
         $attachments = Attachments::make([]);
 
-        $this->assertSame([], $attachments->getAttachments());
-        $this->assertSame([], $attachments->toArray());
+        $this->assertSame([], $attachments->getAttachments(), 'Attachments collection should be an empty array when constructed with no data');
+        $this->assertSame([], $attachments->toArray(), 'Attachments::toArray() should return an empty array when no attachments are present');
     }
 }

--- a/tests/Models/AttachmentsTest.php
+++ b/tests/Models/AttachmentsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Attachment;
+use CaptureHigherEd\LaravelJira\Models\Attachments;
+use PHPUnit\Framework\TestCase;
+
+class AttachmentsTest extends TestCase
+{
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            [
+                'id' => '1',
+                'filename' => 'a.png',
+                'mimeType' => 'image/png',
+                'size' => 100,
+                'content' => 'https://example.com/a.png',
+                'self' => 'https://example.com/attachment/1',
+            ],
+            [
+                'id' => '2',
+                'filename' => 'b.pdf',
+                'mimeType' => 'application/pdf',
+                'size' => 200,
+                'content' => 'https://example.com/b.pdf',
+                'self' => 'https://example.com/attachment/2',
+            ],
+        ];
+
+        $attachments = Attachments::make($data);
+
+        $this->assertCount(2, $attachments->getAttachments());
+        $this->assertContainsOnlyInstancesOf(Attachment::class, $attachments->getAttachments());
+        $this->assertSame($data, $attachments->toArray());
+    }
+
+    public function test_make_with_empty_array(): void
+    {
+        $attachments = Attachments::make([]);
+
+        $this->assertSame([], $attachments->getAttachments());
+        $this->assertSame([], $attachments->toArray());
+    }
+}

--- a/tests/Models/CommentTest.php
+++ b/tests/Models/CommentTest.php
@@ -3,18 +3,34 @@
 namespace CaptureHigherEd\LaravelJira\Tests\Models;
 
 use CaptureHigherEd\LaravelJira\Models\Comment;
+use CaptureHigherEd\LaravelJira\Models\User;
 use PHPUnit\Framework\TestCase;
 
 class CommentTest extends TestCase
 {
     public function test_make_roundtrip(): void
     {
+        $authorData = [
+            'accountId' => 'abc123',
+            'displayName' => 'Jane Smith',
+            'emailAddress' => 'jane@example.com',
+            'active' => true,
+            'self' => '',
+            'accountType' => '',
+            'timeZone' => '',
+            'locale' => '',
+            'avatarUrls' => [],
+        ];
         $data = [
             'id' => '10001',
             'body' => ['type' => 'doc', 'version' => 1, 'content' => []],
             'created' => '2024-01-01T00:00:00.000+0000',
             'updated' => '2024-01-02T00:00:00.000+0000',
             'self' => 'https://example.atlassian.net/rest/api/3/issue/KEY-1/comment/10001',
+            'author' => $authorData,
+            'updateAuthor' => $authorData,
+            'jsdPublic' => true,
+            'visibility' => [],
         ];
 
         $comment = Comment::make($data);
@@ -31,5 +47,28 @@ class CommentTest extends TestCase
         $this->assertSame('', $comment->getCreated(), 'Comment created timestamp should default to an empty string when not provided');
         $this->assertSame('', $comment->getUpdated(), 'Comment updated timestamp should default to an empty string when not provided');
         $this->assertSame('', $comment->getSelf(), 'Comment self URL should default to an empty string when not provided');
+        $this->assertNull($comment->getAuthor(), 'Comment author should default to null when not provided');
+        $this->assertNull($comment->getUpdateAuthor(), 'Comment updateAuthor should default to null when not provided');
+        $this->assertTrue($comment->getJsdPublic(), 'Comment jsdPublic should default to true when not provided');
+        $this->assertSame([], $comment->getVisibility(), 'Comment visibility should default to an empty array when not provided');
+    }
+
+    public function test_author_is_hydrated_as_user(): void
+    {
+        $comment = Comment::make([
+            'id' => '1',
+            'author' => ['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => 'alice@example.com', 'active' => true],
+        ]);
+
+        $this->assertInstanceOf(User::class, $comment->getAuthor(), 'Comment author should be hydrated as a User instance');
+        $this->assertSame('u1', $comment->getAuthor()?->getKey(), 'Comment author accountId should be hydrated correctly');
+    }
+
+    public function test_make_without_author_returns_null(): void
+    {
+        $comment = Comment::make(['id' => '1']);
+
+        $this->assertNull($comment->getAuthor(), 'Comment author should be null when not present in the response data');
+        $this->assertNull($comment->getUpdateAuthor(), 'Comment updateAuthor should be null when not present in the response data');
     }
 }

--- a/tests/Models/CommentTest.php
+++ b/tests/Models/CommentTest.php
@@ -19,17 +19,17 @@ class CommentTest extends TestCase
 
         $comment = Comment::make($data);
 
-        $this->assertSame($data, $comment->toArray());
+        $this->assertSame($data, $comment->toArray(), 'Comment::toArray() should return the same data that was passed to make()');
     }
 
     public function test_make_with_empty_data(): void
     {
         $comment = Comment::make();
 
-        $this->assertSame('', $comment->getId());
-        $this->assertSame([], $comment->getBody());
-        $this->assertSame('', $comment->getCreated());
-        $this->assertSame('', $comment->getUpdated());
-        $this->assertSame('', $comment->getSelf());
+        $this->assertSame('', $comment->getId(), 'Comment ID should default to an empty string when not provided');
+        $this->assertSame([], $comment->getBody(), 'Comment body should default to an empty array when not provided');
+        $this->assertSame('', $comment->getCreated(), 'Comment created timestamp should default to an empty string when not provided');
+        $this->assertSame('', $comment->getUpdated(), 'Comment updated timestamp should default to an empty string when not provided');
+        $this->assertSame('', $comment->getSelf(), 'Comment self URL should default to an empty string when not provided');
     }
 }

--- a/tests/Models/CommentTest.php
+++ b/tests/Models/CommentTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Comment;
+use PHPUnit\Framework\TestCase;
+
+class CommentTest extends TestCase
+{
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => '10001',
+            'body' => ['type' => 'doc', 'version' => 1, 'content' => []],
+            'created' => '2024-01-01T00:00:00.000+0000',
+            'updated' => '2024-01-02T00:00:00.000+0000',
+            'self' => 'https://example.atlassian.net/rest/api/3/issue/KEY-1/comment/10001',
+        ];
+
+        $comment = Comment::make($data);
+
+        $this->assertSame($data, $comment->toArray());
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $comment = Comment::make();
+
+        $this->assertSame('', $comment->getId());
+        $this->assertSame([], $comment->getBody());
+        $this->assertSame('', $comment->getCreated());
+        $this->assertSame('', $comment->getUpdated());
+        $this->assertSame('', $comment->getSelf());
+    }
+}

--- a/tests/Models/FieldTest.php
+++ b/tests/Models/FieldTest.php
@@ -19,6 +19,7 @@ class FieldTest extends TestCase
             'searchable' => true,
             'clauseNames' => ['cf[10001]', 'Story Points'],
             'schema' => ['type' => 'number', 'custom' => 'com.atlassian.jira.plugin.system.customfieldtypes:float'],
+            'scope' => ['type' => 'PROJECT', 'project' => ['id' => '10000']],
         ];
 
         $field = Field::make($data);
@@ -39,6 +40,7 @@ class FieldTest extends TestCase
         $this->assertFalse($field->getSearchable(), 'Field searchable flag should default to false when not provided');
         $this->assertSame([], $field->getClauseNames(), 'Field clauseNames should default to an empty array when not provided');
         $this->assertSame([], $field->getSchema(), 'Field schema should default to an empty array when not provided');
+        $this->assertSame([], $field->getScope(), 'Field scope should default to an empty array when not provided');
     }
 
     public function test_make_with_partial_data(): void

--- a/tests/Models/FieldTest.php
+++ b/tests/Models/FieldTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Field;
+use PHPUnit\Framework\TestCase;
+
+class FieldTest extends TestCase
+{
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => 'customfield_10001',
+            'key' => 'customfield_10001',
+            'name' => 'Story Points',
+            'custom' => true,
+            'orderable' => true,
+            'navigable' => true,
+            'searchable' => true,
+            'clauseNames' => ['cf[10001]', 'Story Points'],
+            'schema' => ['type' => 'number', 'custom' => 'com.atlassian.jira.plugin.system.customfieldtypes:float'],
+        ];
+
+        $field = Field::make($data);
+
+        $this->assertSame($data, $field->toArray());
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $field = Field::make();
+
+        $this->assertSame('', $field->getId());
+        $this->assertSame('', $field->getKey());
+        $this->assertSame('', $field->getName());
+        $this->assertFalse($field->getCustom());
+        $this->assertFalse($field->getOrderable());
+        $this->assertFalse($field->getNavigable());
+        $this->assertFalse($field->getSearchable());
+        $this->assertSame([], $field->getClauseNames());
+        $this->assertSame([], $field->getSchema());
+    }
+
+    public function test_make_with_partial_data(): void
+    {
+        $field = Field::make([
+            'id' => 'summary',
+            'name' => 'Summary',
+            'custom' => false,
+        ]);
+
+        $this->assertSame('summary', $field->getId());
+        $this->assertSame('Summary', $field->getName());
+        $this->assertFalse($field->getCustom());
+        $this->assertSame('', $field->getKey());
+    }
+}

--- a/tests/Models/FieldTest.php
+++ b/tests/Models/FieldTest.php
@@ -23,22 +23,22 @@ class FieldTest extends TestCase
 
         $field = Field::make($data);
 
-        $this->assertSame($data, $field->toArray());
+        $this->assertSame($data, $field->toArray(), 'Field::toArray() should return the same data that was passed to make()');
     }
 
     public function test_make_with_empty_data(): void
     {
         $field = Field::make();
 
-        $this->assertSame('', $field->getId());
-        $this->assertSame('', $field->getKey());
-        $this->assertSame('', $field->getName());
-        $this->assertFalse($field->getCustom());
-        $this->assertFalse($field->getOrderable());
-        $this->assertFalse($field->getNavigable());
-        $this->assertFalse($field->getSearchable());
-        $this->assertSame([], $field->getClauseNames());
-        $this->assertSame([], $field->getSchema());
+        $this->assertSame('', $field->getId(), 'Field ID should default to an empty string when not provided');
+        $this->assertSame('', $field->getKey(), 'Field key should default to an empty string when not provided');
+        $this->assertSame('', $field->getName(), 'Field name should default to an empty string when not provided');
+        $this->assertFalse($field->getCustom(), 'Field custom flag should default to false when not provided');
+        $this->assertFalse($field->getOrderable(), 'Field orderable flag should default to false when not provided');
+        $this->assertFalse($field->getNavigable(), 'Field navigable flag should default to false when not provided');
+        $this->assertFalse($field->getSearchable(), 'Field searchable flag should default to false when not provided');
+        $this->assertSame([], $field->getClauseNames(), 'Field clauseNames should default to an empty array when not provided');
+        $this->assertSame([], $field->getSchema(), 'Field schema should default to an empty array when not provided');
     }
 
     public function test_make_with_partial_data(): void
@@ -49,9 +49,9 @@ class FieldTest extends TestCase
             'custom' => false,
         ]);
 
-        $this->assertSame('summary', $field->getId());
-        $this->assertSame('Summary', $field->getName());
-        $this->assertFalse($field->getCustom());
-        $this->assertSame('', $field->getKey());
+        $this->assertSame('summary', $field->getId(), 'Field ID should match the provided id value');
+        $this->assertSame('Summary', $field->getName(), 'Field name should match the provided name value');
+        $this->assertFalse($field->getCustom(), 'Field custom flag should be false when explicitly set to false');
+        $this->assertSame('', $field->getKey(), 'Field key should default to an empty string when not included in partial data');
     }
 }

--- a/tests/Models/FieldsTest.php
+++ b/tests/Models/FieldsTest.php
@@ -49,6 +49,8 @@ class FieldsTest extends TestCase
         ];
     }
 
+    // ── make & toArray ────────────────────────────────────────────────────
+
     public function test_make_roundtrip(): void
     {
         $data = $this->fieldData();
@@ -66,6 +68,8 @@ class FieldsTest extends TestCase
         $this->assertSame([], $fields->getFields(), 'Fields collection should be an empty array when constructed with no data');
         $this->assertSame([], $fields->toArray(), 'Fields::toArray() should return an empty array when no fields are present');
     }
+
+    // ── Custom field lookup ───────────────────────────────────────────────
 
     public function test_get_custom_fields_filters_by_key_prefix(): void
     {

--- a/tests/Models/FieldsTest.php
+++ b/tests/Models/FieldsTest.php
@@ -54,17 +54,17 @@ class FieldsTest extends TestCase
         $data = $this->fieldData();
         $fields = Fields::make($data);
 
-        $this->assertCount(3, $fields->getFields());
-        $this->assertContainsOnlyInstancesOf(Field::class, $fields->getFields());
-        $this->assertSame($data, $fields->toArray());
+        $this->assertCount(3, $fields->getFields(), 'Fields collection should contain exactly 3 items matching the input array');
+        $this->assertContainsOnlyInstancesOf(Field::class, $fields->getFields(), 'All items in the Fields collection should be hydrated as Field instances');
+        $this->assertSame($data, $fields->toArray(), 'Fields::toArray() should return the same data that was passed to make()');
     }
 
     public function test_make_with_empty_array(): void
     {
         $fields = Fields::make([]);
 
-        $this->assertSame([], $fields->getFields());
-        $this->assertSame([], $fields->toArray());
+        $this->assertSame([], $fields->getFields(), 'Fields collection should be an empty array when constructed with no data');
+        $this->assertSame([], $fields->toArray(), 'Fields::toArray() should return an empty array when no fields are present');
     }
 
     public function test_get_custom_fields_filters_by_key_prefix(): void
@@ -73,9 +73,9 @@ class FieldsTest extends TestCase
 
         $custom = $fields->getCustomFields();
 
-        $this->assertCount(2, $custom);
+        $this->assertCount(2, $custom, 'getCustomFields() should return only the 2 fields with a customfield_ key prefix');
         foreach ($custom as $field) {
-            $this->assertStringStartsWith('customfield_', $field->getKey());
+            $this->assertStringStartsWith('customfield_', $field->getKey(), 'Each custom field returned by getCustomFields() should have a key starting with "customfield_"');
         }
     }
 
@@ -85,7 +85,7 @@ class FieldsTest extends TestCase
 
         $id = $fields->getCustomFieldId('Story Points');
 
-        $this->assertSame('customfield_10001', $id);
+        $this->assertSame('customfield_10001', $id, 'getCustomFieldId() should return the correct field ID for "Story Points"');
     }
 
     public function test_get_custom_field_id_throws_when_not_found(): void
@@ -103,8 +103,8 @@ class FieldsTest extends TestCase
 
         $field = $fields->getCustomField('Epic Link');
 
-        $this->assertInstanceOf(Field::class, $field);
-        $this->assertSame('customfield_10002', $field->getId());
+        $this->assertInstanceOf(Field::class, $field, 'getCustomField() should return a Field instance for a known custom field name');
+        $this->assertSame('customfield_10002', $field->getId(), 'getCustomField() should return the field with the correct ID for "Epic Link"');
     }
 
     public function test_get_custom_field_throws_when_not_found(): void

--- a/tests/Models/FieldsTest.php
+++ b/tests/Models/FieldsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Exception\CustomFieldDoesNotExistException;
+use CaptureHigherEd\LaravelJira\Models\Field;
+use CaptureHigherEd\LaravelJira\Models\Fields;
+use PHPUnit\Framework\TestCase;
+
+class FieldsTest extends TestCase
+{
+    /** @return array<int, array<string, mixed>> */
+    private function fieldData(): array
+    {
+        return [
+            [
+                'id' => 'summary',
+                'key' => 'summary',
+                'name' => 'Summary',
+                'custom' => false,
+                'orderable' => true,
+                'navigable' => true,
+                'searchable' => true,
+                'clauseNames' => ['summary'],
+                'schema' => ['type' => 'string'],
+            ],
+            [
+                'id' => 'customfield_10001',
+                'key' => 'customfield_10001',
+                'name' => 'Story Points',
+                'custom' => true,
+                'orderable' => true,
+                'navigable' => true,
+                'searchable' => true,
+                'clauseNames' => ['cf[10001]'],
+                'schema' => ['type' => 'number'],
+            ],
+            [
+                'id' => 'customfield_10002',
+                'key' => 'customfield_10002',
+                'name' => 'Epic Link',
+                'custom' => true,
+                'orderable' => false,
+                'navigable' => true,
+                'searchable' => true,
+                'clauseNames' => ['cf[10002]'],
+                'schema' => ['type' => 'string'],
+            ],
+        ];
+    }
+
+    public function test_make_roundtrip(): void
+    {
+        $data = $this->fieldData();
+        $fields = Fields::make($data);
+
+        $this->assertCount(3, $fields->getFields());
+        $this->assertContainsOnlyInstancesOf(Field::class, $fields->getFields());
+        $this->assertSame($data, $fields->toArray());
+    }
+
+    public function test_make_with_empty_array(): void
+    {
+        $fields = Fields::make([]);
+
+        $this->assertSame([], $fields->getFields());
+        $this->assertSame([], $fields->toArray());
+    }
+
+    public function test_get_custom_fields_filters_by_key_prefix(): void
+    {
+        $fields = Fields::make($this->fieldData());
+
+        $custom = $fields->getCustomFields();
+
+        $this->assertCount(2, $custom);
+        foreach ($custom as $field) {
+            $this->assertStringStartsWith('customfield_', $field->getKey());
+        }
+    }
+
+    public function test_get_custom_field_id_returns_id(): void
+    {
+        $fields = Fields::make($this->fieldData());
+
+        $id = $fields->getCustomFieldId('Story Points');
+
+        $this->assertSame('customfield_10001', $id);
+    }
+
+    public function test_get_custom_field_id_throws_when_not_found(): void
+    {
+        $fields = Fields::make($this->fieldData());
+
+        $this->expectException(CustomFieldDoesNotExistException::class);
+
+        $fields->getCustomFieldId('Nonexistent Field');
+    }
+
+    public function test_get_custom_field_returns_field(): void
+    {
+        $fields = Fields::make($this->fieldData());
+
+        $field = $fields->getCustomField('Epic Link');
+
+        $this->assertInstanceOf(Field::class, $field);
+        $this->assertSame('customfield_10002', $field->getId());
+    }
+
+    public function test_get_custom_field_throws_when_not_found(): void
+    {
+        $fields = Fields::make($this->fieldData());
+
+        $this->expectException(CustomFieldDoesNotExistException::class);
+
+        $fields->getCustomField('Nonexistent Field');
+    }
+
+    public function test_get_custom_field_id_ignores_non_custom_fields(): void
+    {
+        // 'Summary' field has key 'summary' (not customfield_*), so it's not in custom fields
+        $fields = Fields::make($this->fieldData());
+
+        $this->expectException(CustomFieldDoesNotExistException::class);
+
+        $fields->getCustomFieldId('Summary');
+    }
+}

--- a/tests/Models/FieldsTest.php
+++ b/tests/Models/FieldsTest.php
@@ -23,6 +23,7 @@ class FieldsTest extends TestCase
                 'searchable' => true,
                 'clauseNames' => ['summary'],
                 'schema' => ['type' => 'string'],
+                'scope' => [],
             ],
             [
                 'id' => 'customfield_10001',
@@ -34,6 +35,7 @@ class FieldsTest extends TestCase
                 'searchable' => true,
                 'clauseNames' => ['cf[10001]'],
                 'schema' => ['type' => 'number'],
+                'scope' => ['type' => 'PROJECT', 'project' => ['id' => '10000']],
             ],
             [
                 'id' => 'customfield_10002',
@@ -45,6 +47,7 @@ class FieldsTest extends TestCase
                 'searchable' => true,
                 'clauseNames' => ['cf[10002]'],
                 'schema' => ['type' => 'string'],
+                'scope' => [],
             ],
         ];
     }

--- a/tests/Models/IssueTest.php
+++ b/tests/Models/IssueTest.php
@@ -3,21 +3,14 @@
 namespace CaptureHigherEd\LaravelJira\Tests\Models;
 
 use CaptureHigherEd\LaravelJira\Models\Issue;
-use CaptureHigherEd\LaravelJira\Providers\IntegrationServiceProvider;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\UsesTestbench;
 use Orchestra\Testbench\TestCase;
 
 class IssueTest extends TestCase
 {
-    protected function getPackageProviders($app): array
-    {
-        return [IntegrationServiceProvider::class];
-    }
+    use UsesTestbench;
 
-    protected function defineEnvironment($app): void
-    {
-        $app['config']->set('jira.token', base64_encode('test@example.com:fake-token'));
-        $app['config']->set('jira.domain', 'https://test.atlassian.net');
-    }
+    // ── make & toArray ────────────────────────────────────────────────────
 
     public function test_make_roundtrip(): void
     {
@@ -43,6 +36,8 @@ class IssueTest extends TestCase
         $this->assertSame([], $issue->getFields(), 'Issue fields should default to an empty array when not provided');
         $this->assertNull($issue->getSummary(), 'Issue summary should be null when fields are not provided');
     }
+
+    // ── Field filtering ───────────────────────────────────────────────────
 
     public function test_make_filters_null_fields(): void
     {
@@ -85,29 +80,25 @@ class IssueTest extends TestCase
         $this->assertFalse($fields['active'], 'Issue fields active value should remain false after null filtering');
     }
 
-    public function test_set_custom_field_by_value_multi_select(): void
+    // ── Field setters ─────────────────────────────────────────────────────
+
+    /** @dataProvider customFieldByValueProvider */
+    public function test_set_custom_field_by_value(string $value, ?bool $multiSelect, mixed $expected, string $message): void
     {
         $issue = Issue::make();
-        $issue->setCustomFieldByValue('customfield_10001', 'Option A', true);
+        $issue->setCustomFieldByValue('customfield_10001', $value, $multiSelect);
 
-        $this->assertSame([['value' => 'Option A']], $issue->getFields()['customfield_10001'], 'Multi-select custom field should be stored as an array of value objects');
+        $this->assertSame($expected, $issue->getFields()['customfield_10001'], $message);
     }
 
-    public function test_set_custom_field_by_value_single_select(): void
+    /** @return array<string, array{string, ?bool, mixed, string}> */
+    public static function customFieldByValueProvider(): array
     {
-        $issue = Issue::make();
-        $issue->setCustomFieldByValue('customfield_10001', 'Option B', false);
-
-        $this->assertSame(['value' => 'Option B'], $issue->getFields()['customfield_10001'], 'Single-select custom field should be stored as a single value object');
-    }
-
-    public function test_set_custom_field_by_value_null_acts_as_single(): void
-    {
-        // null is falsy so treated as single-select
-        $issue = Issue::make();
-        $issue->setCustomFieldByValue('customfield_10001', 'Option C', null);
-
-        $this->assertSame(['value' => 'Option C'], $issue->getFields()['customfield_10001'], 'Custom field with null multi-select flag should be treated as single-select');
+        return [
+            'multi-select' => ['Option A', true,  [['value' => 'Option A']], 'Multi-select custom field should be stored as an array of value objects'],
+            'single-select' => ['Option B', false, ['value' => 'Option B'],   'Single-select custom field should be stored as a single value object'],
+            'null acts as single' => ['Option C', null,  ['value' => 'Option C'],   'Custom field with null multi-select flag should be treated as single-select'],
+        ];
     }
 
     public function test_set_project_by_key(): void
@@ -138,6 +129,8 @@ class IssueTest extends TestCase
 
         $this->assertSame(['id' => 'abc123'], $issue->getFields()['reporter'], 'setReporter() should store the reporter as an array with an id property');
     }
+
+    // ── Computed properties ───────────────────────────────────────────────
 
     public function test_get_link_uses_config_domain(): void
     {

--- a/tests/Models/IssueTest.php
+++ b/tests/Models/IssueTest.php
@@ -29,19 +29,19 @@ class IssueTest extends TestCase
 
         $issue = Issue::make($data);
 
-        $this->assertSame('10001', $issue->getId());
-        $this->assertSame('KEY-1', $issue->getKey());
-        $this->assertSame('Test Issue', $issue->getSummary());
+        $this->assertSame('10001', $issue->getId(), 'Issue ID should match the input id value');
+        $this->assertSame('KEY-1', $issue->getKey(), 'Issue key should match the input key value');
+        $this->assertSame('Test Issue', $issue->getSummary(), 'Issue summary should match the summary field from the input data');
     }
 
     public function test_make_with_empty_data(): void
     {
         $issue = Issue::make();
 
-        $this->assertSame('', $issue->getId());
-        $this->assertSame('', $issue->getKey());
-        $this->assertSame([], $issue->getFields());
-        $this->assertNull($issue->getSummary());
+        $this->assertSame('', $issue->getId(), 'Issue ID should default to an empty string when not provided');
+        $this->assertSame('', $issue->getKey(), 'Issue key should default to an empty string when not provided');
+        $this->assertSame([], $issue->getFields(), 'Issue fields should default to an empty array when not provided');
+        $this->assertNull($issue->getSummary(), 'Issue summary should be null when fields are not provided');
     }
 
     public function test_make_filters_null_fields(): void
@@ -58,9 +58,9 @@ class IssueTest extends TestCase
 
         $fields = $issue->getFields();
 
-        $this->assertArrayHasKey('summary', $fields);
-        $this->assertArrayNotHasKey('description', $fields);
-        $this->assertArrayNotHasKey('priority', $fields);
+        $this->assertArrayHasKey('summary', $fields, 'Issue fields should retain the summary key when its value is not null');
+        $this->assertArrayNotHasKey('description', $fields, 'Issue fields should remove the description key when its value is null');
+        $this->assertArrayNotHasKey('priority', $fields, 'Issue fields should remove the priority key when its value is null');
     }
 
     public function test_make_preserves_falsy_non_null_values(): void
@@ -77,12 +77,12 @@ class IssueTest extends TestCase
 
         $fields = $issue->getFields();
 
-        $this->assertArrayHasKey('count', $fields);
-        $this->assertArrayHasKey('label', $fields);
-        $this->assertArrayHasKey('active', $fields);
-        $this->assertSame(0, $fields['count']);
-        $this->assertSame('', $fields['label']);
-        $this->assertFalse($fields['active']);
+        $this->assertArrayHasKey('count', $fields, 'Issue fields should retain the count key even when the value is 0');
+        $this->assertArrayHasKey('label', $fields, 'Issue fields should retain the label key even when the value is an empty string');
+        $this->assertArrayHasKey('active', $fields, 'Issue fields should retain the active key even when the value is false');
+        $this->assertSame(0, $fields['count'], 'Issue fields count value should remain 0 after null filtering');
+        $this->assertSame('', $fields['label'], 'Issue fields label value should remain an empty string after null filtering');
+        $this->assertFalse($fields['active'], 'Issue fields active value should remain false after null filtering');
     }
 
     public function test_set_custom_field_by_value_multi_select(): void
@@ -90,7 +90,7 @@ class IssueTest extends TestCase
         $issue = Issue::make();
         $issue->setCustomFieldByValue('customfield_10001', 'Option A', true);
 
-        $this->assertSame([['value' => 'Option A']], $issue->getFields()['customfield_10001']);
+        $this->assertSame([['value' => 'Option A']], $issue->getFields()['customfield_10001'], 'Multi-select custom field should be stored as an array of value objects');
     }
 
     public function test_set_custom_field_by_value_single_select(): void
@@ -98,7 +98,7 @@ class IssueTest extends TestCase
         $issue = Issue::make();
         $issue->setCustomFieldByValue('customfield_10001', 'Option B', false);
 
-        $this->assertSame(['value' => 'Option B'], $issue->getFields()['customfield_10001']);
+        $this->assertSame(['value' => 'Option B'], $issue->getFields()['customfield_10001'], 'Single-select custom field should be stored as a single value object');
     }
 
     public function test_set_custom_field_by_value_null_acts_as_single(): void
@@ -107,7 +107,7 @@ class IssueTest extends TestCase
         $issue = Issue::make();
         $issue->setCustomFieldByValue('customfield_10001', 'Option C', null);
 
-        $this->assertSame(['value' => 'Option C'], $issue->getFields()['customfield_10001']);
+        $this->assertSame(['value' => 'Option C'], $issue->getFields()['customfield_10001'], 'Custom field with null multi-select flag should be treated as single-select');
     }
 
     public function test_set_project_by_key(): void
@@ -115,7 +115,7 @@ class IssueTest extends TestCase
         $issue = Issue::make();
         $issue->setProjectByKey('CBE4');
 
-        $this->assertSame(['key' => 'CBE4'], $issue->getFields()['project']);
+        $this->assertSame(['key' => 'CBE4'], $issue->getFields()['project'], 'setProjectByKey() should store the project as an array with a key property');
     }
 
     public function test_set_description_wraps_in_adf(): void
@@ -126,9 +126,9 @@ class IssueTest extends TestCase
 
         $description = $issue->getFields()['description'];
 
-        $this->assertSame($content, $description['content']);
-        $this->assertSame('doc', $description['type']);
-        $this->assertSame(1, $description['version']);
+        $this->assertSame($content, $description['content'], 'setDescription() should embed the provided content inside the ADF document wrapper');
+        $this->assertSame('doc', $description['type'], 'setDescription() should set the ADF document type to "doc"');
+        $this->assertSame(1, $description['version'], 'setDescription() should set the ADF document version to 1');
     }
 
     public function test_set_reporter_wraps_in_id(): void
@@ -136,20 +136,20 @@ class IssueTest extends TestCase
         $issue = Issue::make();
         $issue->setReporter('abc123');
 
-        $this->assertSame(['id' => 'abc123'], $issue->getFields()['reporter']);
+        $this->assertSame(['id' => 'abc123'], $issue->getFields()['reporter'], 'setReporter() should store the reporter as an array with an id property');
     }
 
     public function test_get_link_uses_config_domain(): void
     {
         $issue = Issue::make(['id' => '1', 'key' => 'KEY-99', 'fields' => []]);
 
-        $this->assertSame('https://test.atlassian.net/browse/KEY-99', $issue->getLink());
+        $this->assertSame('https://test.atlassian.net/browse/KEY-99', $issue->getLink(), 'getLink() should construct the browse URL using the configured Jira domain and the issue key');
     }
 
     public function test_get_summary_returns_null_when_not_set(): void
     {
         $issue = Issue::make(['id' => '1', 'key' => 'KEY-1', 'fields' => []]);
 
-        $this->assertNull($issue->getSummary());
+        $this->assertNull($issue->getSummary(), 'getSummary() should return null when the summary field is not present in the issue fields');
     }
 }

--- a/tests/Models/IssueTest.php
+++ b/tests/Models/IssueTest.php
@@ -3,6 +3,12 @@
 namespace CaptureHigherEd\LaravelJira\Tests\Models;
 
 use CaptureHigherEd\LaravelJira\Models\Issue;
+use CaptureHigherEd\LaravelJira\Models\IssueType;
+use CaptureHigherEd\LaravelJira\Models\Priority;
+use CaptureHigherEd\LaravelJira\Models\Project;
+use CaptureHigherEd\LaravelJira\Models\Resolution;
+use CaptureHigherEd\LaravelJira\Models\Status;
+use CaptureHigherEd\LaravelJira\Models\User;
 use CaptureHigherEd\LaravelJira\Tests\Concerns\UsesTestbench;
 use Orchestra\Testbench\TestCase;
 
@@ -17,13 +23,15 @@ class IssueTest extends TestCase
         $data = [
             'id' => '10001',
             'key' => 'KEY-1',
-            'fields' => ['summary' => 'Test Issue', 'priority' => 'High'],
+            'self' => 'https://example.atlassian.net/rest/api/3/issue/10001',
+            'fields' => ['summary' => 'Test Issue'],
         ];
 
         $issue = Issue::make($data);
 
         $this->assertSame('10001', $issue->getId(), 'Issue ID should match the input id value');
         $this->assertSame('KEY-1', $issue->getKey(), 'Issue key should match the input key value');
+        $this->assertSame('https://example.atlassian.net/rest/api/3/issue/10001', $issue->getSelf(), 'Issue self URL should match the input self value');
         $this->assertSame('Test Issue', $issue->getSummary(), 'Issue summary should match the summary field from the input data');
     }
 
@@ -128,6 +136,119 @@ class IssueTest extends TestCase
         $issue->setReporter('abc123');
 
         $this->assertSame(['id' => 'abc123'], $issue->getFields()['reporter'], 'setReporter() should store the reporter as an array with an id property');
+    }
+
+    // ── Typed field getters ───────────────────────────────────────────────
+
+    public function test_get_status_returns_status_model(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'K-1', 'fields' => [
+            'status' => ['id' => '1', 'name' => 'In Progress', 'description' => '', 'iconUrl' => '', 'self' => '', 'statusCategory' => []],
+        ]]);
+
+        $this->assertInstanceOf(Status::class, $issue->getStatus(), 'getStatus() should return a Status instance when status field is present');
+        $this->assertSame('In Progress', $issue->getStatus()?->getName(), 'getStatus() should hydrate the status name correctly');
+    }
+
+    public function test_get_status_returns_null_when_absent(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'K-1', 'fields' => []]);
+
+        $this->assertNull($issue->getStatus(), 'getStatus() should return null when the status field is not present');
+    }
+
+    public function test_get_assignee_returns_user_model(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'K-1', 'fields' => [
+            'assignee' => ['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => 'alice@example.com', 'active' => true],
+        ]]);
+
+        $this->assertInstanceOf(User::class, $issue->getAssignee(), 'getAssignee() should return a User instance when assignee field is present');
+        $this->assertSame('u1', $issue->getAssignee()?->getKey(), 'getAssignee() should hydrate the accountId correctly');
+    }
+
+    public function test_get_reporter_returns_user_model(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'K-1', 'fields' => [
+            'reporter' => ['accountId' => 'u2', 'displayName' => 'Bob', 'emailAddress' => 'bob@example.com', 'active' => true],
+        ]]);
+
+        $this->assertInstanceOf(User::class, $issue->getReporter(), 'getReporter() should return a User instance when reporter field is present');
+        $this->assertSame('u2', $issue->getReporter()?->getKey(), 'getReporter() should hydrate the accountId correctly');
+    }
+
+    public function test_get_priority_returns_priority_model(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'K-1', 'fields' => [
+            'priority' => ['id' => '2', 'name' => 'High', 'description' => '', 'iconUrl' => '', 'self' => '', 'statusColor' => '', 'isDefault' => false, 'avatarId' => 0],
+        ]]);
+
+        $this->assertInstanceOf(Priority::class, $issue->getPriority(), 'getPriority() should return a Priority instance when priority field is present');
+        $this->assertSame('High', $issue->getPriority()?->getName(), 'getPriority() should hydrate the priority name correctly');
+    }
+
+    public function test_get_issue_type_returns_issue_type_model(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'K-1', 'fields' => [
+            'issuetype' => ['id' => '10001', 'name' => 'Bug', 'description' => '', 'subtask' => false, 'iconUrl' => '', 'self' => ''],
+        ]]);
+
+        $this->assertInstanceOf(IssueType::class, $issue->getIssueType(), 'getIssueType() should return an IssueType instance when issuetype field is present');
+        $this->assertSame('Bug', $issue->getIssueType()?->getName(), 'getIssueType() should hydrate the issue type name correctly');
+    }
+
+    public function test_get_project_returns_project_model(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'K-1', 'fields' => [
+            'project' => ['id' => '10000', 'key' => 'TEST', 'name' => 'Test Project', 'self' => '', 'projectTypeKey' => 'software', 'simplified' => false, 'avatarUrls' => []],
+        ]]);
+
+        $this->assertInstanceOf(Project::class, $issue->getProject(), 'getProject() should return a Project instance when project field is present');
+        $this->assertSame('TEST', $issue->getProject()?->getKey(), 'getProject() should hydrate the project key correctly');
+    }
+
+    public function test_get_resolution_returns_resolution_model(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'K-1', 'fields' => [
+            'resolution' => ['id' => '1', 'name' => 'Done', 'description' => 'Work is done.', 'self' => ''],
+        ]]);
+
+        $this->assertInstanceOf(Resolution::class, $issue->getResolution(), 'getResolution() should return a Resolution instance when resolution field is present');
+        $this->assertSame('Done', $issue->getResolution()?->getName(), 'getResolution() should hydrate the resolution name correctly');
+    }
+
+    public function test_get_scalar_field_getters(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'K-1', 'fields' => [
+            'created' => '2024-01-01T00:00:00.000+0000',
+            'updated' => '2024-01-02T00:00:00.000+0000',
+            'duedate' => '2024-06-30',
+            'resolutiondate' => '2024-01-15T12:00:00.000+0000',
+            'labels' => ['backend', 'urgent'],
+        ]]);
+
+        $this->assertSame('2024-01-01T00:00:00.000+0000', $issue->getCreated(), 'getCreated() should return the created timestamp from fields');
+        $this->assertSame('2024-01-02T00:00:00.000+0000', $issue->getUpdated(), 'getUpdated() should return the updated timestamp from fields');
+        $this->assertSame('2024-06-30', $issue->getDueDate(), 'getDueDate() should return the due date from fields');
+        $this->assertSame('2024-01-15T12:00:00.000+0000', $issue->getResolutionDate(), 'getResolutionDate() should return the resolution date from fields');
+        $this->assertSame(['backend', 'urgent'], $issue->getLabels(), 'getLabels() should return the labels array from fields');
+    }
+
+    public function test_typed_getters_return_null_when_fields_absent(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'K-1', 'fields' => []]);
+
+        $this->assertNull($issue->getAssignee(), 'getAssignee() should return null when assignee field is not present');
+        $this->assertNull($issue->getReporter(), 'getReporter() should return null when reporter field is not present');
+        $this->assertNull($issue->getPriority(), 'getPriority() should return null when priority field is not present');
+        $this->assertNull($issue->getIssueType(), 'getIssueType() should return null when issuetype field is not present');
+        $this->assertNull($issue->getProject(), 'getProject() should return null when project field is not present');
+        $this->assertNull($issue->getResolution(), 'getResolution() should return null when resolution field is not present');
+        $this->assertNull($issue->getCreated(), 'getCreated() should return null when created field is not present');
+        $this->assertNull($issue->getUpdated(), 'getUpdated() should return null when updated field is not present');
+        $this->assertNull($issue->getDueDate(), 'getDueDate() should return null when duedate field is not present');
+        $this->assertNull($issue->getResolutionDate(), 'getResolutionDate() should return null when resolutiondate field is not present');
+        $this->assertNull($issue->getLabels(), 'getLabels() should return null when labels field is not present');
     }
 
     // ── Computed properties ───────────────────────────────────────────────

--- a/tests/Models/IssueTest.php
+++ b/tests/Models/IssueTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Issue;
+use CaptureHigherEd\LaravelJira\Providers\IntegrationServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class IssueTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [IntegrationServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('jira.token', base64_encode('test@example.com:fake-token'));
+        $app['config']->set('jira.domain', 'https://test.atlassian.net');
+    }
+
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => '10001',
+            'key' => 'KEY-1',
+            'fields' => ['summary' => 'Test Issue', 'priority' => 'High'],
+        ];
+
+        $issue = Issue::make($data);
+
+        $this->assertSame('10001', $issue->getId());
+        $this->assertSame('KEY-1', $issue->getKey());
+        $this->assertSame('Test Issue', $issue->getSummary());
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $issue = Issue::make();
+
+        $this->assertSame('', $issue->getId());
+        $this->assertSame('', $issue->getKey());
+        $this->assertSame([], $issue->getFields());
+        $this->assertNull($issue->getSummary());
+    }
+
+    public function test_make_filters_null_fields(): void
+    {
+        $issue = Issue::make([
+            'id' => '1',
+            'key' => 'KEY-1',
+            'fields' => [
+                'summary' => 'Test',
+                'description' => null,
+                'priority' => null,
+            ],
+        ]);
+
+        $fields = $issue->getFields();
+
+        $this->assertArrayHasKey('summary', $fields);
+        $this->assertArrayNotHasKey('description', $fields);
+        $this->assertArrayNotHasKey('priority', $fields);
+    }
+
+    public function test_make_preserves_falsy_non_null_values(): void
+    {
+        $issue = Issue::make([
+            'id' => '1',
+            'key' => 'KEY-1',
+            'fields' => [
+                'count' => 0,
+                'label' => '',
+                'active' => false,
+            ],
+        ]);
+
+        $fields = $issue->getFields();
+
+        $this->assertArrayHasKey('count', $fields);
+        $this->assertArrayHasKey('label', $fields);
+        $this->assertArrayHasKey('active', $fields);
+        $this->assertSame(0, $fields['count']);
+        $this->assertSame('', $fields['label']);
+        $this->assertFalse($fields['active']);
+    }
+
+    public function test_set_custom_field_by_value_multi_select(): void
+    {
+        $issue = Issue::make();
+        $issue->setCustomFieldByValue('customfield_10001', 'Option A', true);
+
+        $this->assertSame([['value' => 'Option A']], $issue->getFields()['customfield_10001']);
+    }
+
+    public function test_set_custom_field_by_value_single_select(): void
+    {
+        $issue = Issue::make();
+        $issue->setCustomFieldByValue('customfield_10001', 'Option B', false);
+
+        $this->assertSame(['value' => 'Option B'], $issue->getFields()['customfield_10001']);
+    }
+
+    public function test_set_custom_field_by_value_null_acts_as_single(): void
+    {
+        // null is falsy so treated as single-select
+        $issue = Issue::make();
+        $issue->setCustomFieldByValue('customfield_10001', 'Option C', null);
+
+        $this->assertSame(['value' => 'Option C'], $issue->getFields()['customfield_10001']);
+    }
+
+    public function test_set_project_by_key(): void
+    {
+        $issue = Issue::make();
+        $issue->setProjectByKey('CBE4');
+
+        $this->assertSame(['key' => 'CBE4'], $issue->getFields()['project']);
+    }
+
+    public function test_set_description_wraps_in_adf(): void
+    {
+        $issue = Issue::make();
+        $content = [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Hello']]]];
+        $issue->setDescription($content);
+
+        $description = $issue->getFields()['description'];
+
+        $this->assertSame($content, $description['content']);
+        $this->assertSame('doc', $description['type']);
+        $this->assertSame(1, $description['version']);
+    }
+
+    public function test_set_reporter_wraps_in_id(): void
+    {
+        $issue = Issue::make();
+        $issue->setReporter('abc123');
+
+        $this->assertSame(['id' => 'abc123'], $issue->getFields()['reporter']);
+    }
+
+    public function test_get_link_uses_config_domain(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'KEY-99', 'fields' => []]);
+
+        $this->assertSame('https://test.atlassian.net/browse/KEY-99', $issue->getLink());
+    }
+
+    public function test_get_summary_returns_null_when_not_set(): void
+    {
+        $issue = Issue::make(['id' => '1', 'key' => 'KEY-1', 'fields' => []]);
+
+        $this->assertNull($issue->getSummary());
+    }
+}

--- a/tests/Models/PriorityTest.php
+++ b/tests/Models/PriorityTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Priority;
+use PHPUnit\Framework\TestCase;
+
+class PriorityTest extends TestCase
+{
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => '2',
+            'name' => 'High',
+            'description' => 'High priority.',
+            'iconUrl' => 'https://example.com/high.png',
+            'self' => 'https://example.atlassian.net/rest/api/3/priority/2',
+            'statusColor' => '#FF0000',
+            'isDefault' => false,
+            'avatarId' => 10100,
+        ];
+
+        $priority = Priority::make($data);
+
+        $this->assertSame($data, $priority->toArray(), 'Priority::toArray() should return the same data that was passed to make()');
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $priority = Priority::make();
+
+        $this->assertSame('', $priority->getId(), 'Priority ID should default to an empty string when not provided');
+        $this->assertSame('', $priority->getName(), 'Priority name should default to an empty string when not provided');
+        $this->assertSame('', $priority->getDescription(), 'Priority description should default to an empty string when not provided');
+        $this->assertSame('', $priority->getIconUrl(), 'Priority iconUrl should default to an empty string when not provided');
+        $this->assertSame('', $priority->getSelf(), 'Priority self URL should default to an empty string when not provided');
+        $this->assertSame('', $priority->getStatusColor(), 'Priority statusColor should default to an empty string when not provided');
+        $this->assertFalse($priority->getIsDefault(), 'Priority isDefault should default to false when not provided');
+        $this->assertSame(0, $priority->getAvatarId(), 'Priority avatarId should default to 0 when not provided');
+    }
+
+    public function test_avatar_id_cast_to_int(): void
+    {
+        $priority = Priority::make(['avatarId' => '10100']);
+
+        $this->assertSame(10100, $priority->getAvatarId(), 'Priority avatarId should be cast to integer even when provided as a string');
+        $this->assertIsInt($priority->getAvatarId(), 'Priority avatarId should be stored and returned as an integer');
+    }
+}

--- a/tests/Models/ProjectTest.php
+++ b/tests/Models/ProjectTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Project;
+use PHPUnit\Framework\TestCase;
+
+class ProjectTest extends TestCase
+{
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => '10000',
+            'key' => 'TEST',
+            'name' => 'Test Project',
+            'self' => 'https://example.atlassian.net/rest/api/3/project/10000',
+            'projectTypeKey' => 'software',
+            'simplified' => false,
+            'avatarUrls' => ['16x16' => 'https://example.com/16.png', '48x48' => 'https://example.com/48.png'],
+        ];
+
+        $project = Project::make($data);
+
+        $this->assertSame($data, $project->toArray(), 'Project::toArray() should return the same data that was passed to make()');
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $project = Project::make();
+
+        $this->assertSame('', $project->getId(), 'Project ID should default to an empty string when not provided');
+        $this->assertSame('', $project->getKey(), 'Project key should default to an empty string when not provided');
+        $this->assertSame('', $project->getName(), 'Project name should default to an empty string when not provided');
+        $this->assertSame('', $project->getSelf(), 'Project self URL should default to an empty string when not provided');
+        $this->assertSame('', $project->getProjectTypeKey(), 'Project projectTypeKey should default to an empty string when not provided');
+        $this->assertFalse($project->getSimplified(), 'Project simplified should default to false when not provided');
+        $this->assertSame([], $project->getAvatarUrls(), 'Project avatarUrls should default to an empty array when not provided');
+    }
+}

--- a/tests/Models/ResolutionTest.php
+++ b/tests/Models/ResolutionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Resolution;
+use PHPUnit\Framework\TestCase;
+
+class ResolutionTest extends TestCase
+{
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => '1',
+            'name' => 'Done',
+            'description' => 'Work is done.',
+            'self' => 'https://example.atlassian.net/rest/api/3/resolution/1',
+        ];
+
+        $resolution = Resolution::make($data);
+
+        $this->assertSame($data, $resolution->toArray(), 'Resolution::toArray() should return the same data that was passed to make()');
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $resolution = Resolution::make();
+
+        $this->assertSame('', $resolution->getId(), 'Resolution ID should default to an empty string when not provided');
+        $this->assertSame('', $resolution->getName(), 'Resolution name should default to an empty string when not provided');
+        $this->assertSame('', $resolution->getDescription(), 'Resolution description should default to an empty string when not provided');
+        $this->assertSame('', $resolution->getSelf(), 'Resolution self URL should default to an empty string when not provided');
+    }
+}

--- a/tests/Models/SearchTest.php
+++ b/tests/Models/SearchTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Issue;
+use CaptureHigherEd\LaravelJira\Models\Search;
+use PHPUnit\Framework\TestCase;
+
+class SearchTest extends TestCase
+{
+    public function test_make_roundtrip(): void
+    {
+        $issue1 = ['id' => '1', 'key' => 'KEY-1', 'fields' => ['summary' => 'First']];
+        $issue2 = ['id' => '2', 'key' => 'KEY-2', 'fields' => ['summary' => 'Second']];
+
+        $search = Search::make(['issues' => [$issue1, $issue2]]);
+
+        $this->assertCount(2, $search->getIssues());
+        $this->assertSame('KEY-1', $search->getIssues()[0]->getKey());
+        $this->assertSame('KEY-2', $search->getIssues()[1]->getKey());
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $search = Search::make([]);
+
+        $this->assertSame([], $search->getIssues());
+    }
+
+    public function test_make_without_issues_key(): void
+    {
+        $search = Search::make(['other' => 'data']);
+
+        $this->assertSame([], $search->getIssues());
+    }
+
+    public function test_make_hydrates_each_issue(): void
+    {
+        $search = Search::make([
+            'issues' => [
+                ['id' => '1', 'key' => 'KEY-1', 'fields' => []],
+                ['id' => '2', 'key' => 'KEY-2', 'fields' => []],
+            ],
+        ]);
+
+        foreach ($search->getIssues() as $issue) {
+            $this->assertInstanceOf(Issue::class, $issue);
+        }
+    }
+}

--- a/tests/Models/SearchTest.php
+++ b/tests/Models/SearchTest.php
@@ -15,23 +15,23 @@ class SearchTest extends TestCase
 
         $search = Search::make(['issues' => [$issue1, $issue2]]);
 
-        $this->assertCount(2, $search->getIssues());
-        $this->assertSame('KEY-1', $search->getIssues()[0]->getKey());
-        $this->assertSame('KEY-2', $search->getIssues()[1]->getKey());
+        $this->assertCount(2, $search->getIssues(), 'Search result should contain exactly 2 issues matching the input array');
+        $this->assertSame('KEY-1', $search->getIssues()[0]->getKey(), 'First issue key should match KEY-1');
+        $this->assertSame('KEY-2', $search->getIssues()[1]->getKey(), 'Second issue key should match KEY-2');
     }
 
     public function test_make_with_empty_data(): void
     {
         $search = Search::make([]);
 
-        $this->assertSame([], $search->getIssues());
+        $this->assertSame([], $search->getIssues(), 'Search result should contain an empty issues array when constructed with empty data');
     }
 
     public function test_make_without_issues_key(): void
     {
         $search = Search::make(['other' => 'data']);
 
-        $this->assertSame([], $search->getIssues());
+        $this->assertSame([], $search->getIssues(), 'Search result should contain an empty issues array when the issues key is absent from the input data');
     }
 
     public function test_make_hydrates_each_issue(): void
@@ -44,7 +44,7 @@ class SearchTest extends TestCase
         ]);
 
         foreach ($search->getIssues() as $issue) {
-            $this->assertInstanceOf(Issue::class, $issue);
+            $this->assertInstanceOf(Issue::class, $issue, 'Each item in the search results should be hydrated as an Issue instance');
         }
     }
 }

--- a/tests/Models/SearchTest.php
+++ b/tests/Models/SearchTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 class SearchTest extends TestCase
 {
+    // ── make & hydration ──────────────────────────────────────────────────
+
     public function test_make_roundtrip(): void
     {
         $issue1 = ['id' => '1', 'key' => 'KEY-1', 'fields' => ['summary' => 'First']];

--- a/tests/Models/StatusTest.php
+++ b/tests/Models/StatusTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Status;
+use PHPUnit\Framework\TestCase;
+
+class StatusTest extends TestCase
+{
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => '3',
+            'name' => 'In Progress',
+            'description' => 'Work is in progress.',
+            'iconUrl' => 'https://example.com/icon.png',
+            'self' => 'https://example.atlassian.net/rest/api/3/status/3',
+            'statusCategory' => ['id' => 4, 'key' => 'indeterminate', 'name' => 'In Progress', 'colorName' => 'yellow'],
+        ];
+
+        $status = Status::make($data);
+
+        $this->assertSame($data, $status->toArray(), 'Status::toArray() should return the same data that was passed to make()');
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $status = Status::make();
+
+        $this->assertSame('', $status->getId(), 'Status ID should default to an empty string when not provided');
+        $this->assertSame('', $status->getName(), 'Status name should default to an empty string when not provided');
+        $this->assertSame('', $status->getDescription(), 'Status description should default to an empty string when not provided');
+        $this->assertSame('', $status->getIconUrl(), 'Status iconUrl should default to an empty string when not provided');
+        $this->assertSame('', $status->getSelf(), 'Status self URL should default to an empty string when not provided');
+        $this->assertSame([], $status->getStatusCategory(), 'Status statusCategory should default to an empty array when not provided');
+    }
+}

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\User;
+use PHPUnit\Framework\TestCase;
+
+class UserTest extends TestCase
+{
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'accountId' => 'abc123',
+            'displayName' => 'Jane Smith',
+            'emailAddress' => 'jane@example.com',
+            'active' => true,
+        ];
+
+        $user = User::make($data);
+
+        $this->assertSame($data, $user->toArray());
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $user = User::make();
+
+        $this->assertSame('', $user->getKey());
+        $this->assertSame('', $user->getName());
+        $this->assertSame('', $user->getEmail());
+        $this->assertFalse($user->getActive());
+    }
+
+    public function test_active_is_boolean(): void
+    {
+        $user = User::make(['active' => true]);
+
+        $this->assertTrue($user->getActive());
+        $this->assertIsBool($user->getActive());
+    }
+}

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 class UserTest extends TestCase
 {
+    // ── make & toArray ────────────────────────────────────────────────────
+
     public function test_make_roundtrip(): void
     {
         $data = [
@@ -30,6 +32,8 @@ class UserTest extends TestCase
         $this->assertSame('', $user->getEmail(), 'User email address should default to an empty string when not provided');
         $this->assertFalse($user->getActive(), 'User active flag should default to false when not provided');
     }
+
+    // ── Type casting ──────────────────────────────────────────────────────
 
     public function test_active_is_boolean(): void
     {

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -16,6 +16,11 @@ class UserTest extends TestCase
             'displayName' => 'Jane Smith',
             'emailAddress' => 'jane@example.com',
             'active' => true,
+            'self' => 'https://example.atlassian.net/rest/api/3/user?accountId=abc123',
+            'accountType' => 'atlassian',
+            'timeZone' => 'Australia/Sydney',
+            'locale' => 'en_AU',
+            'avatarUrls' => ['16x16' => 'https://example.com/16.png', '48x48' => 'https://example.com/48.png'],
         ];
 
         $user = User::make($data);
@@ -31,6 +36,11 @@ class UserTest extends TestCase
         $this->assertSame('', $user->getName(), 'User display name should default to an empty string when not provided');
         $this->assertSame('', $user->getEmail(), 'User email address should default to an empty string when not provided');
         $this->assertFalse($user->getActive(), 'User active flag should default to false when not provided');
+        $this->assertSame('', $user->getSelf(), 'User self URL should default to an empty string when not provided');
+        $this->assertSame('', $user->getAccountType(), 'User accountType should default to an empty string when not provided');
+        $this->assertSame('', $user->getTimeZone(), 'User timeZone should default to an empty string when not provided');
+        $this->assertSame('', $user->getLocale(), 'User locale should default to an empty string when not provided');
+        $this->assertSame([], $user->getAvatarUrls(), 'User avatarUrls should default to an empty array when not provided');
     }
 
     // ── Type casting ──────────────────────────────────────────────────────

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -18,24 +18,24 @@ class UserTest extends TestCase
 
         $user = User::make($data);
 
-        $this->assertSame($data, $user->toArray());
+        $this->assertSame($data, $user->toArray(), 'User::toArray() should return the same data that was passed to make()');
     }
 
     public function test_make_with_empty_data(): void
     {
         $user = User::make();
 
-        $this->assertSame('', $user->getKey());
-        $this->assertSame('', $user->getName());
-        $this->assertSame('', $user->getEmail());
-        $this->assertFalse($user->getActive());
+        $this->assertSame('', $user->getKey(), 'User account ID (key) should default to an empty string when not provided');
+        $this->assertSame('', $user->getName(), 'User display name should default to an empty string when not provided');
+        $this->assertSame('', $user->getEmail(), 'User email address should default to an empty string when not provided');
+        $this->assertFalse($user->getActive(), 'User active flag should default to false when not provided');
     }
 
     public function test_active_is_boolean(): void
     {
         $user = User::make(['active' => true]);
 
-        $this->assertTrue($user->getActive());
-        $this->assertIsBool($user->getActive());
+        $this->assertTrue($user->getActive(), 'User active flag should be true when set to true');
+        $this->assertIsBool($user->getActive(), 'User active flag should be stored and returned as a boolean');
     }
 }

--- a/tests/Models/UsersTest.php
+++ b/tests/Models/UsersTest.php
@@ -23,17 +23,17 @@ class UsersTest extends TestCase
         $data = $this->userData();
         $users = Users::make($data);
 
-        $this->assertCount(3, $users->getUsers());
-        $this->assertContainsOnlyInstancesOf(User::class, $users->getUsers());
-        $this->assertSame($data, $users->toArray());
+        $this->assertCount(3, $users->getUsers(), 'Users collection should contain exactly 3 items matching the input array');
+        $this->assertContainsOnlyInstancesOf(User::class, $users->getUsers(), 'All items in the Users collection should be hydrated as User instances');
+        $this->assertSame($data, $users->toArray(), 'Users::toArray() should return the same data that was passed to make()');
     }
 
     public function test_make_with_empty_array(): void
     {
         $users = Users::make([]);
 
-        $this->assertSame([], $users->getUsers());
-        $this->assertSame([], $users->toArray());
+        $this->assertSame([], $users->getUsers(), 'Users collection should be an empty array when constructed with no data');
+        $this->assertSame([], $users->toArray(), 'Users::toArray() should return an empty array when no users are present');
     }
 
     public function test_get_active_users_filters_correctly(): void
@@ -42,9 +42,9 @@ class UsersTest extends TestCase
 
         $active = $users->getActiveUsers();
 
-        $this->assertCount(2, $active);
+        $this->assertCount(2, $active, 'getActiveUsers() should return exactly 2 active users out of 3 total');
         foreach ($active as $user) {
-            $this->assertTrue($user->getActive());
+            $this->assertTrue($user->getActive(), 'Each user returned by getActiveUsers() should have an active flag of true');
         }
     }
 
@@ -54,6 +54,6 @@ class UsersTest extends TestCase
             ['accountId' => 'u1', 'displayName' => 'A', 'emailAddress' => 'a@example.com', 'active' => false],
         ]);
 
-        $this->assertSame([], array_values($users->getActiveUsers()));
+        $this->assertSame([], array_values($users->getActiveUsers()), 'getActiveUsers() should return an empty array when all users are inactive');
     }
 }

--- a/tests/Models/UsersTest.php
+++ b/tests/Models/UsersTest.php
@@ -12,9 +12,9 @@ class UsersTest extends TestCase
     private function userData(): array
     {
         return [
-            ['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => 'alice@example.com', 'active' => true],
-            ['accountId' => 'u2', 'displayName' => 'Bob', 'emailAddress' => 'bob@example.com', 'active' => true],
-            ['accountId' => 'u3', 'displayName' => 'Charlie', 'emailAddress' => 'charlie@example.com', 'active' => false],
+            ['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => 'alice@example.com', 'active' => true, 'self' => '', 'accountType' => '', 'timeZone' => '', 'locale' => '', 'avatarUrls' => []],
+            ['accountId' => 'u2', 'displayName' => 'Bob', 'emailAddress' => 'bob@example.com', 'active' => true, 'self' => '', 'accountType' => '', 'timeZone' => '', 'locale' => '', 'avatarUrls' => []],
+            ['accountId' => 'u3', 'displayName' => 'Charlie', 'emailAddress' => 'charlie@example.com', 'active' => false, 'self' => '', 'accountType' => '', 'timeZone' => '', 'locale' => '', 'avatarUrls' => []],
         ];
     }
 
@@ -55,7 +55,7 @@ class UsersTest extends TestCase
     public function test_get_active_users_returns_empty_when_none_active(): void
     {
         $users = Users::make([
-            ['accountId' => 'u1', 'displayName' => 'A', 'emailAddress' => 'a@example.com', 'active' => false],
+            ['accountId' => 'u1', 'displayName' => 'A', 'emailAddress' => 'a@example.com', 'active' => false, 'self' => '', 'accountType' => '', 'timeZone' => '', 'locale' => '', 'avatarUrls' => []],
         ]);
 
         $this->assertSame([], array_values($users->getActiveUsers()), 'getActiveUsers() should return an empty array when all users are inactive');

--- a/tests/Models/UsersTest.php
+++ b/tests/Models/UsersTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\User;
+use CaptureHigherEd\LaravelJira\Models\Users;
+use PHPUnit\Framework\TestCase;
+
+class UsersTest extends TestCase
+{
+    /** @return array<int, array<string, mixed>> */
+    private function userData(): array
+    {
+        return [
+            ['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => 'alice@example.com', 'active' => true],
+            ['accountId' => 'u2', 'displayName' => 'Bob', 'emailAddress' => 'bob@example.com', 'active' => true],
+            ['accountId' => 'u3', 'displayName' => 'Charlie', 'emailAddress' => 'charlie@example.com', 'active' => false],
+        ];
+    }
+
+    public function test_make_roundtrip(): void
+    {
+        $data = $this->userData();
+        $users = Users::make($data);
+
+        $this->assertCount(3, $users->getUsers());
+        $this->assertContainsOnlyInstancesOf(User::class, $users->getUsers());
+        $this->assertSame($data, $users->toArray());
+    }
+
+    public function test_make_with_empty_array(): void
+    {
+        $users = Users::make([]);
+
+        $this->assertSame([], $users->getUsers());
+        $this->assertSame([], $users->toArray());
+    }
+
+    public function test_get_active_users_filters_correctly(): void
+    {
+        $users = Users::make($this->userData());
+
+        $active = $users->getActiveUsers();
+
+        $this->assertCount(2, $active);
+        foreach ($active as $user) {
+            $this->assertTrue($user->getActive());
+        }
+    }
+
+    public function test_get_active_users_returns_empty_when_none_active(): void
+    {
+        $users = Users::make([
+            ['accountId' => 'u1', 'displayName' => 'A', 'emailAddress' => 'a@example.com', 'active' => false],
+        ]);
+
+        $this->assertSame([], array_values($users->getActiveUsers()));
+    }
+}

--- a/tests/Models/UsersTest.php
+++ b/tests/Models/UsersTest.php
@@ -18,6 +18,8 @@ class UsersTest extends TestCase
         ];
     }
 
+    // ── make & toArray ────────────────────────────────────────────────────
+
     public function test_make_roundtrip(): void
     {
         $data = $this->userData();
@@ -35,6 +37,8 @@ class UsersTest extends TestCase
         $this->assertSame([], $users->getUsers(), 'Users collection should be an empty array when constructed with no data');
         $this->assertSame([], $users->toArray(), 'Users::toArray() should return an empty array when no users are present');
     }
+
+    // ── Filtering ─────────────────────────────────────────────────────────
 
     public function test_get_active_users_filters_correctly(): void
     {


### PR DESCRIPTION
Comprehensive quality improvements to the Laravel-Jira package including bug fixes, type safety, error handling, CI setup, and a working test suite.

___

### Changes
- Fix `RuntimeException` thrown when JIRA token is missing
- Fix `array_filter` dropping falsy values (now uses strict `!== null`)
- Fix `attach()`/`comment()` incorrectly hydrating response as `Issue`
- Fix `HttpClientException` double-consuming the response stream
- Fix `getOptions()` moved from `Field` DTO to `Api/Fields` where it belongs
- Add `toArray()` on all models (`Field`, `Fields`, `Search`, `User`, `Users`)
- Type all getters/setters; `User.$active` is `bool`; strict `===` throughout
- Handle HTTP 422/500/502/503; guard `json_decode` on 204/empty body
- Use `['json' => $params]` instead of `['body' => json_encode()]` for Guzzle
- Add PHP 8.2/8.3/8.4 × Laravel 10/11/12 CI matrix (`.github/workflows/ci.yml`)
- Add PHPStan (level 6), Pint (Laravel preset) config
- Replace broken integration test with proper Orchestra Testbench unit test
- Update `phpunit.xml` to PHPUnit 10+ (remove deprecated attributes)
- Update `composer.json`: type=library, PHP ^8.1, Guzzle explicit dep, auto-discovery