### PR TITLE
Expand Jira API coverage and reduce model boilerplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0] - Unreleased
+## [2.0.0] - Unreleased
 
 ### Breaking Changes
 
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`Field::getOptions()` removed** — use `Api\Fields::getFieldOptions(Field $field, string $projectKey, string $issueTypeName)` instead
 - **PHP minimum version raised** from `^8.0.2` to `^8.1`
 - **Laravel minimum version raised** from `^8.0||^9.0` to `^10.0||^11.0||^12.0`
+- **`Issues::comment()` now delegates to `Comments::create()`** — behavior unchanged but internal routing differs
+- **All model `const` declarations removed** — any code referencing e.g. `User::NAME` or `Issue::FIELDS` must use string literals
+- **All models now extend `Model` base class** instead of implementing `ApiResponse` directly
 
 ### Added
 
@@ -27,6 +30,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI matrix via GitHub Actions: PHP 8.2 / 8.3 / 8.4 × Laravel 10 / 11 / 12
 - PHPStan (level 6) and Pint (Laravel preset) configuration
 - Comprehensive test suite: 115 tests across models, API classes, exceptions, and the service provider
+- `Api\Projects` — `index()`, `show()`
+- `Api\Comments` — `index()`, `show()`, `create()`, `update()`, `delete()`
+- `Api\Worklogs` — `index()`, `create()`, `update()`, `delete()`
+- `Api\IssueLinks` — `create()`, `show()`, `delete()`, `getTypes()`
+- `Api\Attachments` — `show()`, `delete()`, `getMeta()`
+- `Api\Fields::getLabels()` for label retrieval
+- `Issues::getTransitions()`, `transition()`, `assign()`, `getWatchers()`, `addWatcher()`, `removeWatcher()`
+- `Users::search()`, `myself()`
+- `Jira` entry point methods: `projects()`, `comments()`, `worklogs()`, `issueLinks()`, `attachments()`
+- 10 new models: `Transition`, `Transitions`, `Projects`, `Watchers`, `Comments` (collection), `Worklog`, `Worklogs`, `IssueLink`, `IssueLinkType`, `IssueLinkTypes`
+- Abstract `Model` base class implementing `ApiResponse`
+- `Issue` typed getters: `getStatus()`, `getAssignee()`, `getReporter()`, `getPriority()`, `getIssueType()`, `getProject()`, `getResolution()`, etc.
+- `FieldMeta` and `FieldMetas` models for createmeta responses
+- `IssueTypes` collection model
+- `HttpApi::httpDelete()` now accepts query parameters
+- Test suite expanded to 199 tests
 
 ### Fixed
 
@@ -41,6 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `User::$active` is now strictly typed as `bool`
 - `HttpApi` constructor now accepts `GuzzleHttp\ClientInterface` (PSR) instead of the concrete `Client`
 - All `HttpClientException` factory methods now declare `self` as their return type
+- All 27 models refactored: constructor promotion, `const` declarations removed, `make()` uses named args
+- Collection models use `array_map` instead of `foreach` loops
+- `Issues::search()` migrated to `/rest/api/3/search/jql` endpoint
 
 ## [1.0.5] - 2025-09-02
 
@@ -78,8 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/1.1.0...HEAD
-[1.1.0]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/1.0.5...1.1.0
+[Unreleased]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/2.0.0...HEAD
+[2.0.0]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/1.0.5...2.0.0
 [1.0.5]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.4...1.0.5
 [1.0.4]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.2...v1.0.3

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ use CaptureHigherEd\LaravelJira\Jira;
 $jira = app(Jira::class);
 ```
 
+---
+
 ### Issues
 
 ```php
@@ -70,21 +72,180 @@ $created = $jira->issues()->create($payload->toArray());
 // Update an issue
 $jira->issues()->update('CBE4-123', ['fields' => ['summary' => 'Updated title']]);
 
+// Delete an issue
+$jira->issues()->delete('CBE4-123');
+```
+
+#### Transitions
+
+```php
+// Get available transitions
+$transitions = $jira->issues()->getTransitions('CBE4-123');
+foreach ($transitions->getTransitions() as $transition) {
+    echo $transition->getId() . ': ' . $transition->getName();
+}
+
+// Transition an issue to a new status
+$jira->issues()->transition('CBE4-123', ['transition' => ['id' => '31']]);
+```
+
+#### Assignment
+
+```php
+$jira->issues()->assign('CBE4-123', $accountId);
+```
+
+#### Watchers
+
+```php
+// Get watchers
+$watchers = $jira->issues()->getWatchers('CBE4-123');
+echo $watchers->getWatchCount();
+
+// Add / remove a watcher
+$jira->issues()->addWatcher('CBE4-123', $accountId);
+$jira->issues()->removeWatcher('CBE4-123', $accountId);
+```
+
+#### Attachments
+
+```php
+// Attach a file
+$attachments = $jira->issues()->attach('CBE4-123', [
+    ['name' => 'file', 'contents' => fopen('/path/to/file.pdf', 'r'), 'filename' => 'file.pdf']
+]);
+```
+
+#### Create Metadata
+
+```php
+// Get issue types available for a project
+$issueTypes = $jira->issues()->getCreateMetaIssueTypes('CBE4');
+foreach ($issueTypes->getIssueTypes() as $type) {
+    echo $type->getId() . ': ' . $type->getName();
+}
+
+// Get field metadata for a project + issue type
+$fields = $jira->issues()->getCreateMetaFields('CBE4', '10001');
+foreach ($fields->getFields() as $field) {
+    echo $field->getFieldId() . ': ' . $field->getName();
+}
+```
+
+---
+
+### Projects
+
+```php
+// Get all projects
+$projects = $jira->projects()->index();
+foreach ($projects->getProjects() as $project) {
+    echo $project->getKey() . ': ' . $project->getName();
+}
+
+// Get a single project
+$project = $jira->projects()->show('CBE4');
+echo $project->getId();
+```
+
+---
+
+### Comments
+
+```php
+// Get all comments for an issue
+$comments = $jira->comments()->index('CBE4-123');
+foreach ($comments->getComments() as $comment) {
+    echo $comment->getId();
+}
+
+// Get a single comment
+$comment = $jira->comments()->show('CBE4-123', '10001');
+
 // Add a comment
-$comment = $jira->issues()->comment('CBE4-123', [
+$comment = $jira->comments()->create('CBE4-123', [
     'body' => ['type' => 'doc', 'version' => 1, 'content' => [
         ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Hello!']]]
     ]]
 ]);
 
-// Attach a file
-$attachment = $jira->issues()->attach('CBE4-123', [
-    ['name' => 'file', 'contents' => fopen('/path/to/file.pdf', 'r'), 'filename' => 'file.pdf']
+// Update a comment
+$jira->comments()->update('CBE4-123', '10001', ['body' => [/* updated ADF */]]);
+
+// Delete a comment
+$jira->comments()->delete('CBE4-123', '10001');
+
+// Shorthand via issues()
+$comment = $jira->issues()->comment('CBE4-123', ['body' => [/* ADF */]]);
+```
+
+---
+
+### Worklogs
+
+```php
+// Get all worklogs for an issue
+$worklogs = $jira->worklogs()->index('CBE4-123');
+foreach ($worklogs->getWorklogs() as $worklog) {
+    echo $worklog->getTimeSpent();
+}
+
+// Add a worklog
+$worklog = $jira->worklogs()->create('CBE4-123', [
+    'timeSpent' => '2h',
+    'started' => '2024-01-15T09:00:00.000+0000',
 ]);
 
-// Delete an issue
-$jira->issues()->delete('CBE4-123');
+// Update a worklog
+$jira->worklogs()->update('CBE4-123', '10001', ['timeSpent' => '3h']);
+
+// Delete a worklog
+$jira->worklogs()->delete('CBE4-123', '10001');
 ```
+
+---
+
+### Issue Links
+
+```php
+// Link two issues
+$jira->issueLinks()->create([
+    'type' => ['name' => 'Blocks'],
+    'inwardIssue' => ['key' => 'CBE4-123'],
+    'outwardIssue' => ['key' => 'CBE4-456'],
+]);
+
+// Get a link
+$link = $jira->issueLinks()->show('10001');
+echo $link->getType()->getName(); // e.g. "Blocks"
+
+// Delete a link
+$jira->issueLinks()->delete('10001');
+
+// Get all available link types
+$types = $jira->issueLinks()->getTypes();
+foreach ($types->getIssueLinkTypes() as $type) {
+    echo $type->getName();
+}
+```
+
+---
+
+### Attachments
+
+```php
+// Get attachment metadata
+$attachment = $jira->attachments()->show('10001');
+echo $attachment->getFilename();
+
+// Delete an attachment
+$jira->attachments()->delete('10001');
+
+// Get global attachment settings (enabled, max file size)
+$meta = $jira->attachments()->getMeta();
+```
+
+---
 
 ### Fields
 
@@ -100,11 +261,11 @@ foreach ($fields->getCustomFields() as $field) {
 // Look up a custom field ID by name
 $fieldId = $fields->getCustomFieldId('My Custom Field');
 
-// Get allowed values for a field (project + issue type context)
-$field = $fields->getCustomField('Priority');
-$options = $jira->fields()->getFieldOptions($field, 'CBE4', 'Bug');
-// ['High' => 'High', 'Medium' => 'Medium', 'Low' => 'Low']
+// Get all labels
+$labels = $jira->fields()->getLabels();
 ```
+
+---
 
 ### Users
 
@@ -113,12 +274,91 @@ $options = $jira->fields()->getFieldOptions($field, 'CBE4', 'Bug');
 $users = $jira->users()->index();
 
 // Get active users only
-$activeUsers = $users->getActiveUsers();
-
-foreach ($activeUsers as $user) {
+foreach ($users->getActiveUsers() as $user) {
     echo $user->getKey() . ': ' . $user->getName() . ' <' . $user->getEmail() . '>';
 }
+
+// Get a user by account ID
+$user = $jira->users()->show($accountId);
+
+// Search for users
+$results = $jira->users()->search(['query' => 'alice']);
+
+// Get the currently authenticated user
+$me = $jira->users()->myself();
+echo $me->getEmail();
 ```
+
+---
+
+### Pagination
+
+Paginated endpoints implement the `Paginated` interface, which exposes `getTotal()`, `getMaxResults()`, `getStartAt()`, `hasMore()`, and `getNextStartAt()`.
+
+**Single page with manual pagination:**
+
+```php
+$page = $jira->issues()->index(['jql' => 'project = CBE4', 'maxResults' => 50]);
+
+echo $page->getTotal();      // total matching issues
+echo $page->hasMore();       // true if more pages exist
+echo $page->getNextStartAt(); // offset to pass for the next page
+```
+
+**Auto-pagination with generators:**
+
+`paginate()` methods lazily fetch all pages, yielding one model per HTTP response. Use a `foreach` loop to process pages as they arrive:
+
+```php
+// Paginate all search results
+foreach ($jira->issues()->paginate(['jql' => 'project = CBE4']) as $page) {
+    foreach ($page->getIssues() as $issue) {
+        // process issue
+    }
+}
+
+// Paginate comments on an issue
+foreach ($jira->comments()->paginate('CBE4-123') as $page) {
+    foreach ($page->getComments() as $comment) {
+        // process comment
+    }
+}
+
+// Paginate worklogs on an issue
+foreach ($jira->worklogs()->paginate('CBE4-123') as $page) {
+    foreach ($page->getWorklogs() as $worklog) {
+        // process worklog
+    }
+}
+
+// Paginate create-meta issue types
+foreach ($jira->issues()->paginateCreateMetaIssueTypes('CBE4') as $page) {
+    foreach ($page->getIssueTypes() as $type) {
+        // process issue type
+    }
+}
+
+// Paginate create-meta fields for a specific issue type
+foreach ($jira->issues()->paginateCreateMetaFields('CBE4', '10001') as $page) {
+    foreach ($page->getFields() as $field) {
+        // process field
+    }
+}
+```
+
+You can also break early to avoid fetching unnecessary pages:
+
+```php
+foreach ($jira->issues()->paginate(['jql' => 'project = CBE4']) as $page) {
+    foreach ($page->getIssues() as $issue) {
+        if ($issue->getKey() === 'CBE4-42') {
+            break 2;
+        }
+    }
+}
+```
+
+---
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ $jira = app(Jira::class);
 
 ```php
 // Search issues (JQL)
-$search = $jira->issues()->index(['jql' => 'project = CBE4 AND status = "To Do"']);
+$search = $jira->issues()->index(['jql' => 'project = PROJ AND status = "To Do"']);
 foreach ($search->getIssues() as $issue) {
     echo $issue->getKey() . ': ' . $issue->getSummary();
 }
 
 // Get a single issue
-$issue = $jira->issues()->show('CBE4-123');
-echo $issue->getLink(); // https://yourcompany.atlassian.net/browse/CBE4-123
+$issue = $jira->issues()->show('PROJ-123');
+echo $issue->getLink(); // https://yourcompany.atlassian.net/browse/PROJ-123
 
 // Create an issue
 use CaptureHigherEd\LaravelJira\Models\Issue;
 
 $payload = Issue::make()
-    ->setProjectByKey('CBE4')
+    ->setProjectByKey('PROJ')
     ->setIssueTypeByName('Bug')
     ->setSummary('Something is broken')
     ->setDescription([/* Atlassian Document Format content */]);
@@ -70,48 +70,48 @@ $payload = Issue::make()
 $created = $jira->issues()->create($payload->toArray());
 
 // Update an issue
-$jira->issues()->update('CBE4-123', ['fields' => ['summary' => 'Updated title']]);
+$jira->issues()->update('PROJ-123', ['fields' => ['summary' => 'Updated title']]);
 
 // Delete an issue
-$jira->issues()->delete('CBE4-123');
+$jira->issues()->delete('PROJ-123');
 ```
 
 #### Transitions
 
 ```php
 // Get available transitions
-$transitions = $jira->issues()->getTransitions('CBE4-123');
+$transitions = $jira->issues()->getTransitions('PROJ-123');
 foreach ($transitions->getTransitions() as $transition) {
     echo $transition->getId() . ': ' . $transition->getName();
 }
 
 // Transition an issue to a new status
-$jira->issues()->transition('CBE4-123', ['transition' => ['id' => '31']]);
+$jira->issues()->transition('PROJ-123', ['transition' => ['id' => '31']]);
 ```
 
 #### Assignment
 
 ```php
-$jira->issues()->assign('CBE4-123', $accountId);
+$jira->issues()->assign('PROJ-123', $accountId);
 ```
 
 #### Watchers
 
 ```php
 // Get watchers
-$watchers = $jira->issues()->getWatchers('CBE4-123');
+$watchers = $jira->issues()->getWatchers('PROJ-123');
 echo $watchers->getWatchCount();
 
 // Add / remove a watcher
-$jira->issues()->addWatcher('CBE4-123', $accountId);
-$jira->issues()->removeWatcher('CBE4-123', $accountId);
+$jira->issues()->addWatcher('PROJ-123', $accountId);
+$jira->issues()->removeWatcher('PROJ-123', $accountId);
 ```
 
 #### Attachments
 
 ```php
 // Attach a file
-$attachments = $jira->issues()->attach('CBE4-123', [
+$attachments = $jira->issues()->attach('PROJ-123', [
     ['name' => 'file', 'contents' => fopen('/path/to/file.pdf', 'r'), 'filename' => 'file.pdf']
 ]);
 ```
@@ -120,13 +120,13 @@ $attachments = $jira->issues()->attach('CBE4-123', [
 
 ```php
 // Get issue types available for a project
-$issueTypes = $jira->issues()->getCreateMetaIssueTypes('CBE4');
+$issueTypes = $jira->issues()->getCreateMetaIssueTypes('PROJ');
 foreach ($issueTypes->getIssueTypes() as $type) {
     echo $type->getId() . ': ' . $type->getName();
 }
 
 // Get field metadata for a project + issue type
-$fields = $jira->issues()->getCreateMetaFields('CBE4', '10001');
+$fields = $jira->issues()->getCreateMetaFields('PROJ', '10001');
 foreach ($fields->getFields() as $field) {
     echo $field->getFieldId() . ': ' . $field->getName();
 }
@@ -144,7 +144,7 @@ foreach ($projects->getProjects() as $project) {
 }
 
 // Get a single project
-$project = $jira->projects()->show('CBE4');
+$project = $jira->projects()->show('PROJ');
 echo $project->getId();
 ```
 
@@ -154,29 +154,29 @@ echo $project->getId();
 
 ```php
 // Get all comments for an issue
-$comments = $jira->comments()->index('CBE4-123');
+$comments = $jira->comments()->index('PROJ-123');
 foreach ($comments->getComments() as $comment) {
     echo $comment->getId();
 }
 
 // Get a single comment
-$comment = $jira->comments()->show('CBE4-123', '10001');
+$comment = $jira->comments()->show('PROJ-123', '10001');
 
 // Add a comment
-$comment = $jira->comments()->create('CBE4-123', [
+$comment = $jira->comments()->create('PROJ-123', [
     'body' => ['type' => 'doc', 'version' => 1, 'content' => [
         ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Hello!']]]
     ]]
 ]);
 
 // Update a comment
-$jira->comments()->update('CBE4-123', '10001', ['body' => [/* updated ADF */]]);
+$jira->comments()->update('PROJ-123', '10001', ['body' => [/* updated ADF */]]);
 
 // Delete a comment
-$jira->comments()->delete('CBE4-123', '10001');
+$jira->comments()->delete('PROJ-123', '10001');
 
 // Shorthand via issues()
-$comment = $jira->issues()->comment('CBE4-123', ['body' => [/* ADF */]]);
+$comment = $jira->issues()->comment('PROJ-123', ['body' => [/* ADF */]]);
 ```
 
 ---
@@ -185,22 +185,22 @@ $comment = $jira->issues()->comment('CBE4-123', ['body' => [/* ADF */]]);
 
 ```php
 // Get all worklogs for an issue
-$worklogs = $jira->worklogs()->index('CBE4-123');
+$worklogs = $jira->worklogs()->index('PROJ-123');
 foreach ($worklogs->getWorklogs() as $worklog) {
     echo $worklog->getTimeSpent();
 }
 
 // Add a worklog
-$worklog = $jira->worklogs()->create('CBE4-123', [
+$worklog = $jira->worklogs()->create('PROJ-123', [
     'timeSpent' => '2h',
     'started' => '2024-01-15T09:00:00.000+0000',
 ]);
 
 // Update a worklog
-$jira->worklogs()->update('CBE4-123', '10001', ['timeSpent' => '3h']);
+$jira->worklogs()->update('PROJ-123', '10001', ['timeSpent' => '3h']);
 
 // Delete a worklog
-$jira->worklogs()->delete('CBE4-123', '10001');
+$jira->worklogs()->delete('PROJ-123', '10001');
 ```
 
 ---
@@ -211,8 +211,8 @@ $jira->worklogs()->delete('CBE4-123', '10001');
 // Link two issues
 $jira->issueLinks()->create([
     'type' => ['name' => 'Blocks'],
-    'inwardIssue' => ['key' => 'CBE4-123'],
-    'outwardIssue' => ['key' => 'CBE4-456'],
+    'inwardIssue' => ['key' => 'PROJ-123'],
+    'outwardIssue' => ['key' => 'PROJ-456'],
 ]);
 
 // Get a link
@@ -298,7 +298,7 @@ Paginated endpoints implement the `Paginated` interface, which exposes `getTotal
 **Single page with manual pagination:**
 
 ```php
-$page = $jira->issues()->index(['jql' => 'project = CBE4', 'maxResults' => 50]);
+$page = $jira->issues()->index(['jql' => 'project = PROJ', 'maxResults' => 50]);
 
 echo $page->getTotal();      // total matching issues
 echo $page->hasMore();       // true if more pages exist
@@ -311,35 +311,35 @@ echo $page->getNextStartAt(); // offset to pass for the next page
 
 ```php
 // Paginate all search results
-foreach ($jira->issues()->paginate(['jql' => 'project = CBE4']) as $page) {
+foreach ($jira->issues()->paginate(['jql' => 'project = PROJ']) as $page) {
     foreach ($page->getIssues() as $issue) {
         // process issue
     }
 }
 
 // Paginate comments on an issue
-foreach ($jira->comments()->paginate('CBE4-123') as $page) {
+foreach ($jira->comments()->paginate('PROJ-123') as $page) {
     foreach ($page->getComments() as $comment) {
         // process comment
     }
 }
 
 // Paginate worklogs on an issue
-foreach ($jira->worklogs()->paginate('CBE4-123') as $page) {
+foreach ($jira->worklogs()->paginate('PROJ-123') as $page) {
     foreach ($page->getWorklogs() as $worklog) {
         // process worklog
     }
 }
 
 // Paginate create-meta issue types
-foreach ($jira->issues()->paginateCreateMetaIssueTypes('CBE4') as $page) {
+foreach ($jira->issues()->paginateCreateMetaIssueTypes('PROJ') as $page) {
     foreach ($page->getIssueTypes() as $type) {
         // process issue type
     }
 }
 
 // Paginate create-meta fields for a specific issue type
-foreach ($jira->issues()->paginateCreateMetaFields('CBE4', '10001') as $page) {
+foreach ($jira->issues()->paginateCreateMetaFields('PROJ', '10001') as $page) {
     foreach ($page->getFields() as $field) {
         // process field
     }
@@ -349,9 +349,9 @@ foreach ($jira->issues()->paginateCreateMetaFields('CBE4', '10001') as $page) {
 You can also break early to avoid fetching unnecessary pages:
 
 ```php
-foreach ($jira->issues()->paginate(['jql' => 'project = CBE4']) as $page) {
+foreach ($jira->issues()->paginate(['jql' => 'project = PROJ']) as $page) {
     foreach ($page->getIssues() as $issue) {
-        if ($issue->getKey() === 'CBE4-42') {
+        if ($issue->getKey() === 'PROJ-42') {
             break 2;
         }
     }

--- a/src/CaptureHigherEd/LaravelJira/Api/Attachments.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Attachments.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Api;
+
+use CaptureHigherEd\LaravelJira\Models\Attachment;
+
+/**
+ * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-group-issue-attachments
+ */
+class Attachments extends HttpApi
+{
+    /**
+     * Get attachment metadata
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-attachment-attachmentid-get
+     */
+    public function show(string $attachmentId): Attachment
+    {
+        $response = $this->httpGet(sprintf('attachment/%s', $attachmentId));
+
+        return $this->hydrateResponse($response, Attachment::class);
+    }
+
+    /**
+     * Delete an attachment
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-attachment-attachmentid-delete
+     *
+     * @return array<mixed>
+     */
+    public function delete(string $attachmentId): array
+    {
+        $response = $this->httpDelete(sprintf('attachment/%s', $attachmentId));
+
+        return $this->hydrateResponse($response);
+    }
+
+    /**
+     * Get global attachment settings
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-attachment-meta-get
+     *
+     * @return array<mixed>
+     */
+    public function getMeta(): array
+    {
+        $response = $this->httpGet('attachment/meta');
+
+        return $this->hydrateResponse($response);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Api/Comments.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Comments.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Api;
+
+use CaptureHigherEd\LaravelJira\Models\Comment;
+use CaptureHigherEd\LaravelJira\Models\Comments as ModelsComments;
+
+/**
+ * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-group-issue-comments
+ */
+class Comments extends HttpApi
+{
+    /**
+     * Get all comments for an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-get
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function index(string $issueId, array $params = []): ModelsComments
+    {
+        $response = $this->httpGet(sprintf('issue/%s/comment', $issueId), $params);
+
+        return $this->hydrateResponse($response, ModelsComments::class);
+    }
+
+    /**
+     * Get a single comment
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-id-get
+     */
+    public function show(string $issueId, string $commentId): Comment
+    {
+        $response = $this->httpGet(sprintf('issue/%s/comment/%s', $issueId, $commentId));
+
+        return $this->hydrateResponse($response, Comment::class);
+    }
+
+    /**
+     * Add a comment to an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-post
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function create(string $issueId, array $params = []): Comment
+    {
+        $response = $this->httpPost(sprintf('issue/%s/comment', $issueId), $params);
+
+        return $this->hydrateResponse($response, Comment::class);
+    }
+
+    /**
+     * Update a comment
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-id-put
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function update(string $issueId, string $commentId, array $params = []): Comment
+    {
+        $response = $this->httpPut(sprintf('issue/%s/comment/%s', $issueId, $commentId), $params);
+
+        return $this->hydrateResponse($response, Comment::class);
+    }
+
+    /**
+     * Delete a comment
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-id-delete
+     *
+     * @return array<mixed>
+     */
+    public function delete(string $issueId, string $commentId): array
+    {
+        $response = $this->httpDelete(sprintf('issue/%s/comment/%s', $issueId, $commentId));
+
+        return $this->hydrateResponse($response);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Api/Comments.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Comments.php
@@ -77,4 +77,17 @@ class Comments extends HttpApi
 
         return $this->hydrateResponse($response);
     }
+
+    /**
+     * Paginate through all comments for an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-get
+     *
+     * @param  array<string, mixed>  $params
+     * @return \Generator<int, ModelsComments, mixed, void>
+     */
+    public function paginate(string $issueId, array $params = []): \Generator
+    {
+        return $this->paginateGet(sprintf('issue/%s/comment', $issueId), $params, ModelsComments::class);
+    }
 }

--- a/src/CaptureHigherEd/LaravelJira/Api/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Fields.php
@@ -25,6 +25,21 @@ class Fields extends HttpApi
     }
 
     /**
+     * Get all labels
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-rest-api-3-label-get
+     *
+     * @param  array<string, mixed>  $params
+     * @return array<mixed>
+     */
+    public function getLabels(array $params = []): array
+    {
+        $response = $this->httpGet('label', $params);
+
+        return $this->hydrateResponse($response);
+    }
+
+    /**
      * Get allowed values for a specific field within a project and issue type.
      *
      * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-createmeta-get

--- a/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
@@ -3,6 +3,8 @@
 namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Exception\HttpClientException;
+use CaptureHigherEd\LaravelJira\Models\ApiResponse;
+use CaptureHigherEd\LaravelJira\Models\Paginated;
 use GuzzleHttp\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -93,6 +95,30 @@ abstract class HttpApi
             default:
                 throw HttpClientException::unknown($response);
         }
+    }
+
+    /**
+     * Paginate through all pages of a GET endpoint.
+     *
+     * @template T of Paginated&ApiResponse
+     *
+     * @param  array<string, mixed>  $parameters
+     * @param  class-string<T>  $class
+     * @return \Generator<int, T, mixed, void>
+     */
+    protected function paginateGet(string $path, array $parameters, string $class): \Generator
+    {
+        $page = 0;
+        do {
+            $response = $this->httpGet($path, $parameters);
+            $model = $this->hydrateResponse($response, $class);
+            yield $page => $model;
+            $page++;
+            if (! $model->hasMore()) {
+                break;
+            }
+            $parameters['startAt'] = $model->getNextStartAt();
+        } while (true);
     }
 
     protected function hydrateResponse(ResponseInterface $response, ?string $class = null): mixed

--- a/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
@@ -56,10 +56,11 @@ abstract class HttpApi
 
     /**
      * @param  string  $path  Relative API path
+     * @param  array<string, mixed>  $parameters  Query string parameters
      */
-    protected function httpDelete(string $path): ResponseInterface
+    protected function httpDelete(string $path, array $parameters = []): ResponseInterface
     {
-        return $this->httpClient->request('DELETE', $path);
+        return $this->httpClient->request('DELETE', $path, ['query' => $parameters]);
     }
 
     protected function handleErrors(ResponseInterface $response): void

--- a/src/CaptureHigherEd/LaravelJira/Api/IssueLinks.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/IssueLinks.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Api;
+
+use CaptureHigherEd\LaravelJira\Models\IssueLink;
+use CaptureHigherEd\LaravelJira\Models\IssueLinkTypes;
+
+/**
+ * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-links/#api-group-issue-links
+ */
+class IssueLinks extends HttpApi
+{
+    /**
+     * Create an issue link
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-links/#api-rest-api-3-issuelink-post
+     *
+     * @param  array<string, mixed>  $params
+     * @return array<mixed>
+     */
+    public function create(array $params = []): array
+    {
+        $response = $this->httpPost('issueLink', $params);
+
+        return $this->hydrateResponse($response);
+    }
+
+    /**
+     * Get an issue link
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-links/#api-rest-api-3-issuelink-linkid-get
+     */
+    public function show(string $linkId): IssueLink
+    {
+        $response = $this->httpGet(sprintf('issueLink/%s', $linkId));
+
+        return $this->hydrateResponse($response, IssueLink::class);
+    }
+
+    /**
+     * Delete an issue link
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-links/#api-rest-api-3-issuelink-linkid-delete
+     *
+     * @return array<mixed>
+     */
+    public function delete(string $linkId): array
+    {
+        $response = $this->httpDelete(sprintf('issueLink/%s', $linkId));
+
+        return $this->hydrateResponse($response);
+    }
+
+    /**
+     * Get all issue link types
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-link-types/#api-rest-api-3-issuelinktype-get
+     */
+    public function getTypes(): IssueLinkTypes
+    {
+        $response = $this->httpGet('issueLinkType');
+
+        return $this->hydrateResponse($response, IssueLinkTypes::class);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Api/Issues.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Issues.php
@@ -245,4 +245,51 @@ class Issues extends HttpApi
 
         return $this->hydrateResponse($response);
     }
+
+    /**
+     * Paginate through all search results
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-get
+     *
+     * @param  array<string, mixed>  $params
+     * @return \Generator<int, Search, mixed, void>
+     */
+    public function paginate(array $params = []): \Generator
+    {
+        return $this->paginateGet('search/jql', $params, Search::class);
+    }
+
+    /**
+     * Paginate through issue types for a project's create metadata
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-createmeta-projectidorkey-issuetypes-get
+     *
+     * @param  array<string, mixed>  $params
+     * @return \Generator<int, IssueTypes, mixed, void>
+     */
+    public function paginateCreateMetaIssueTypes(string $projectKey, array $params = []): \Generator
+    {
+        return $this->paginateGet(
+            sprintf('issue/createmeta/%s/issuetypes', $projectKey),
+            $params,
+            IssueTypes::class
+        );
+    }
+
+    /**
+     * Paginate through field metadata for a specific project and issue type
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-createmeta-projectidorkey-issuetypes-issuetypeid-get
+     *
+     * @param  array<string, mixed>  $params
+     * @return \Generator<int, FieldMetas, mixed, void>
+     */
+    public function paginateCreateMetaFields(string $projectKey, string $issueTypeId, array $params = []): \Generator
+    {
+        return $this->paginateGet(
+            sprintf('issue/createmeta/%s/issuetypes/%s', $projectKey, $issueTypeId),
+            $params,
+            FieldMetas::class
+        );
+    }
 }

--- a/src/CaptureHigherEd/LaravelJira/Api/Issues.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Issues.php
@@ -8,6 +8,8 @@ use CaptureHigherEd\LaravelJira\Models\FieldMetas;
 use CaptureHigherEd\LaravelJira\Models\Issue;
 use CaptureHigherEd\LaravelJira\Models\IssueTypes;
 use CaptureHigherEd\LaravelJira\Models\Search;
+use CaptureHigherEd\LaravelJira\Models\Transitions;
+use CaptureHigherEd\LaravelJira\Models\Watchers;
 
 /**
  * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-group-issues
@@ -79,9 +81,7 @@ class Issues extends HttpApi
      */
     public function comment(string $issueId, array $params = []): Comment
     {
-        $response = $this->httpPost(sprintf('issue/%s/comment', $issueId), $params);
-
-        return $this->hydrateResponse($response, Comment::class);
+        return (new Comments($this->httpClient))->create($issueId, $params);
     }
 
     /**
@@ -156,6 +156,92 @@ class Issues extends HttpApi
     public function delete(string $issueId): array
     {
         $response = $this->httpDelete(sprintf('issue/%s', $issueId));
+
+        return $this->hydrateResponse($response);
+    }
+
+    /**
+     * Get available transitions for an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-get
+     */
+    public function getTransitions(string $issueId): Transitions
+    {
+        $response = $this->httpGet(sprintf('issue/%s/transitions', $issueId));
+
+        return $this->hydrateResponse($response, Transitions::class);
+    }
+
+    /**
+     * Transition an issue to a new status
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post
+     *
+     * @param  array<string, mixed>  $params
+     * @return array<mixed>
+     */
+    public function transition(string $issueId, array $params = []): array
+    {
+        $response = $this->httpPost(sprintf('issue/%s/transitions', $issueId), $params);
+
+        return $this->hydrateResponse($response);
+    }
+
+    /**
+     * Assign an issue to a user
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-assignee-put
+     *
+     * @return array<mixed>
+     */
+    public function assign(string $issueId, string $accountId): array
+    {
+        $response = $this->httpPut(sprintf('issue/%s/assignee', $issueId), ['accountId' => $accountId]);
+
+        return $this->hydrateResponse($response);
+    }
+
+    /**
+     * Get watchers for an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-watchers/#api-rest-api-3-issue-issueidorkey-watchers-get
+     */
+    public function getWatchers(string $issueId): Watchers
+    {
+        $response = $this->httpGet(sprintf('issue/%s/watchers', $issueId));
+
+        return $this->hydrateResponse($response, Watchers::class);
+    }
+
+    /**
+     * Add a watcher to an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-watchers/#api-rest-api-3-issue-issueidorkey-watchers-post
+     *
+     * Jira expects the body to be a JSON-encoded string (e.g. "accountId"), not an object.
+     *
+     * @return array<mixed>
+     */
+    public function addWatcher(string $issueId, string $accountId): array
+    {
+        $response = $this->httpClient->request('POST', sprintf('issue/%s/watchers', $issueId), [
+            'body' => json_encode($accountId),
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+
+        return $this->hydrateResponse($response);
+    }
+
+    /**
+     * Remove a watcher from an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-watchers/#api-rest-api-3-issue-issueidorkey-watchers-delete
+     *
+     * @return array<mixed>
+     */
+    public function removeWatcher(string $issueId, string $accountId): array
+    {
+        $response = $this->httpDelete(sprintf('issue/%s/watchers', $issueId), ['accountId' => $accountId]);
 
         return $this->hydrateResponse($response);
     }

--- a/src/CaptureHigherEd/LaravelJira/Api/Projects.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Projects.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Api;
+
+use CaptureHigherEd\LaravelJira\Models\Project;
+use CaptureHigherEd\LaravelJira\Models\Projects as ModelsProjects;
+
+/**
+ * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-group-projects
+ */
+class Projects extends HttpApi
+{
+    /**
+     * Get all projects
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-rest-api-3-project-get
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function index(array $params = []): ModelsProjects
+    {
+        $response = $this->httpGet('project', $params);
+
+        return $this->hydrateResponse($response, ModelsProjects::class);
+    }
+
+    /**
+     * Get a project by key or ID
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-rest-api-3-project-projectidorkey-get
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function show(string $projectKey, array $params = []): Project
+    {
+        $response = $this->httpGet(sprintf('project/%s', $projectKey), $params);
+
+        return $this->hydrateResponse($response, Project::class);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Api/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Users.php
@@ -2,6 +2,7 @@
 
 namespace CaptureHigherEd\LaravelJira\Api;
 
+use CaptureHigherEd\LaravelJira\Models\User;
 use CaptureHigherEd\LaravelJira\Models\Users as ModelsUsers;
 
 /**
@@ -21,5 +22,43 @@ class Users extends HttpApi
         $response = $this->httpGet('users', $params);
 
         return $this->hydrateResponse($response, ModelsUsers::class);
+    }
+
+    /**
+     * Get a user by account ID
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/#api-rest-api-3-user-get
+     */
+    public function show(string $accountId): User
+    {
+        $response = $this->httpGet('user', ['accountId' => $accountId]);
+
+        return $this->hydrateResponse($response, User::class);
+    }
+
+    /**
+     * Search for users
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-user-search/#api-rest-api-3-user-search-get
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function search(array $params = []): ModelsUsers
+    {
+        $response = $this->httpGet('user/search', $params);
+
+        return $this->hydrateResponse($response, ModelsUsers::class);
+    }
+
+    /**
+     * Get the currently authenticated user
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-myself/#api-rest-api-3-myself-get
+     */
+    public function myself(): User
+    {
+        $response = $this->httpGet('myself');
+
+        return $this->hydrateResponse($response, User::class);
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Api/Worklogs.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Worklogs.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Api;
+
+use CaptureHigherEd\LaravelJira\Models\Worklog;
+use CaptureHigherEd\LaravelJira\Models\Worklogs as ModelsWorklogs;
+
+/**
+ * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/#api-group-issue-worklogs
+ */
+class Worklogs extends HttpApi
+{
+    /**
+     * Get all worklogs for an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/#api-rest-api-3-issue-issueidorkey-worklog-get
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function index(string $issueId, array $params = []): ModelsWorklogs
+    {
+        $response = $this->httpGet(sprintf('issue/%s/worklog', $issueId), $params);
+
+        return $this->hydrateResponse($response, ModelsWorklogs::class);
+    }
+
+    /**
+     * Add a worklog to an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/#api-rest-api-3-issue-issueidorkey-worklog-post
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function create(string $issueId, array $params = []): Worklog
+    {
+        $response = $this->httpPost(sprintf('issue/%s/worklog', $issueId), $params);
+
+        return $this->hydrateResponse($response, Worklog::class);
+    }
+
+    /**
+     * Update a worklog
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/#api-rest-api-3-issue-issueidorkey-worklog-id-put
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function update(string $issueId, string $worklogId, array $params = []): Worklog
+    {
+        $response = $this->httpPut(sprintf('issue/%s/worklog/%s', $issueId, $worklogId), $params);
+
+        return $this->hydrateResponse($response, Worklog::class);
+    }
+
+    /**
+     * Delete a worklog
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/#api-rest-api-3-issue-issueidorkey-worklog-id-delete
+     *
+     * @return array<mixed>
+     */
+    public function delete(string $issueId, string $worklogId): array
+    {
+        $response = $this->httpDelete(sprintf('issue/%s/worklog/%s', $issueId, $worklogId));
+
+        return $this->hydrateResponse($response);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Api/Worklogs.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Worklogs.php
@@ -65,4 +65,17 @@ class Worklogs extends HttpApi
 
         return $this->hydrateResponse($response);
     }
+
+    /**
+     * Paginate through all worklogs for an issue
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/#api-rest-api-3-issue-issueidorkey-worklog-get
+     *
+     * @param  array<string, mixed>  $params
+     * @return \Generator<int, ModelsWorklogs, mixed, void>
+     */
+    public function paginate(string $issueId, array $params = []): \Generator
+    {
+        return $this->paginateGet(sprintf('issue/%s/worklog', $issueId), $params, ModelsWorklogs::class);
+    }
 }

--- a/src/CaptureHigherEd/LaravelJira/Jira.php
+++ b/src/CaptureHigherEd/LaravelJira/Jira.php
@@ -42,4 +42,29 @@ class Jira
     {
         return new Api\Users($this->httpClient);
     }
+
+    public function projects(): Api\Projects
+    {
+        return new Api\Projects($this->httpClient);
+    }
+
+    public function comments(): Api\Comments
+    {
+        return new Api\Comments($this->httpClient);
+    }
+
+    public function worklogs(): Api\Worklogs
+    {
+        return new Api\Worklogs($this->httpClient);
+    }
+
+    public function issueLinks(): Api\IssueLinks
+    {
+        return new Api\IssueLinks($this->httpClient);
+    }
+
+    public function attachments(): Api\Attachments
+    {
+        return new Api\Attachments($this->httpClient);
+    }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Attachment.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Attachment.php
@@ -2,64 +2,36 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Attachment implements ApiResponse
+final class Attachment extends Model
 {
-    const ID = 'id';
-
-    const FILENAME = 'filename';
-
-    const MIME_TYPE = 'mimeType';
-
-    const SIZE = 'size';
-
-    const CONTENT = 'content';
-
-    const SELF = 'self';
-
-    const AUTHOR = 'author';
-
-    const CREATED = 'created';
-
-    const THUMBNAIL = 'thumbnail';
-
-    private string $id = '';
-
-    private string $filename = '';
-
-    private string $mimeType = '';
-
-    private int $size = 0;
-
-    private string $content = '';
-
-    private string $self = '';
-
-    private ?User $author = null;
-
-    private string $created = '';
-
-    private string $thumbnail = '';
-
-    private function __construct() {}
+    private function __construct(
+        private string $id = '',
+        private string $filename = '',
+        private string $mimeType = '',
+        private int $size = 0,
+        private string $content = '',
+        private string $self = '',
+        private ?User $author = null,
+        private string $created = '',
+        private string $thumbnail = '',
+    ) {}
 
     /**
      * @param  array<string, mixed>  $data
      */
     public static function make(array $data = []): self
     {
-        $model = new self;
-
-        $model->setId($data[self::ID] ?? '');
-        $model->setFilename($data[self::FILENAME] ?? '');
-        $model->setMimeType($data[self::MIME_TYPE] ?? '');
-        $model->setSize((int) ($data[self::SIZE] ?? 0));
-        $model->setContent($data[self::CONTENT] ?? '');
-        $model->setSelf($data[self::SELF] ?? '');
-        $model->setAuthor(isset($data[self::AUTHOR]) ? User::make($data[self::AUTHOR]) : null);
-        $model->setCreated($data[self::CREATED] ?? '');
-        $model->setThumbnail($data[self::THUMBNAIL] ?? '');
-
-        return $model;
+        return new self(
+            id: $data['id'] ?? '',
+            filename: $data['filename'] ?? '',
+            mimeType: $data['mimeType'] ?? '',
+            size: (int) ($data['size'] ?? 0),
+            content: $data['content'] ?? '',
+            self: $data['self'] ?? '',
+            author: isset($data['author']) ? User::make($data['author']) : null,
+            created: $data['created'] ?? '',
+            thumbnail: $data['thumbnail'] ?? '',
+        );
     }
 
     public function getId(): string
@@ -176,15 +148,15 @@ final class Attachment implements ApiResponse
     public function toArray(): array
     {
         return [
-            self::ID => $this->id,
-            self::FILENAME => $this->filename,
-            self::MIME_TYPE => $this->mimeType,
-            self::SIZE => $this->size,
-            self::CONTENT => $this->content,
-            self::SELF => $this->self,
-            self::AUTHOR => $this->author?->toArray(),
-            self::CREATED => $this->created,
-            self::THUMBNAIL => $this->thumbnail,
+            'id' => $this->id,
+            'filename' => $this->filename,
+            'mimeType' => $this->mimeType,
+            'size' => $this->size,
+            'content' => $this->content,
+            'self' => $this->self,
+            'author' => $this->author?->toArray(),
+            'created' => $this->created,
+            'thumbnail' => $this->thumbnail,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Attachments.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Attachments.php
@@ -2,7 +2,7 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Attachments implements ApiResponse
+final class Attachments extends Model
 {
     /** @var array<int, Attachment> */
     private array $attachments = [];
@@ -14,15 +14,9 @@ final class Attachments implements ApiResponse
      */
     public static function make(array $data = []): self
     {
-        $attachments = [];
-
-        foreach ($data as $item) {
-            $attachments[] = Attachment::make($item);
-        }
-
         $model = new self;
 
-        $model->attachments = $attachments;
+        $model->attachments = array_values(array_map(fn (array $item) => Attachment::make($item), $data));
 
         return $model;
     }

--- a/src/CaptureHigherEd/LaravelJira/Models/Comment.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Comment.php
@@ -2,66 +2,40 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Comment implements ApiResponse
+final class Comment extends Model
 {
-    const ID = 'id';
-
-    const BODY = 'body';
-
-    const CREATED = 'created';
-
-    const UPDATED = 'updated';
-
-    const SELF = 'self';
-
-    const AUTHOR = 'author';
-
-    const UPDATE_AUTHOR = 'updateAuthor';
-
-    const JSD_PUBLIC = 'jsdPublic';
-
-    const VISIBILITY = 'visibility';
-
-    private string $id = '';
-
-    /** @var array<mixed> */
-    private array $body = [];
-
-    private string $created = '';
-
-    private string $updated = '';
-
-    private string $self = '';
-
-    private ?User $author = null;
-
-    private ?User $updateAuthor = null;
-
-    private bool $jsdPublic = true;
-
-    /** @var array<string, mixed> */
-    private array $visibility = [];
-
-    private function __construct() {}
+    /**
+     * @param  array<mixed>  $body
+     * @param  array<string, mixed>  $visibility
+     */
+    private function __construct(
+        private string $id = '',
+        private array $body = [],
+        private string $created = '',
+        private string $updated = '',
+        private string $self = '',
+        private ?User $author = null,
+        private ?User $updateAuthor = null,
+        private bool $jsdPublic = true,
+        private array $visibility = [],
+    ) {}
 
     /**
      * @param  array<string, mixed>  $data
      */
     public static function make(array $data = []): self
     {
-        $model = new self;
-
-        $model->setId($data[self::ID] ?? '');
-        $model->setBody($data[self::BODY] ?? []);
-        $model->setCreated($data[self::CREATED] ?? '');
-        $model->setUpdated($data[self::UPDATED] ?? '');
-        $model->setSelf($data[self::SELF] ?? '');
-        $model->setAuthor(isset($data[self::AUTHOR]) ? User::make($data[self::AUTHOR]) : null);
-        $model->setUpdateAuthor(isset($data[self::UPDATE_AUTHOR]) ? User::make($data[self::UPDATE_AUTHOR]) : null);
-        $model->setJsdPublic($data[self::JSD_PUBLIC] ?? true);
-        $model->setVisibility($data[self::VISIBILITY] ?? []);
-
-        return $model;
+        return new self(
+            id: $data['id'] ?? '',
+            body: $data['body'] ?? [],
+            created: $data['created'] ?? '',
+            updated: $data['updated'] ?? '',
+            self: $data['self'] ?? '',
+            author: isset($data['author']) ? User::make($data['author']) : null,
+            updateAuthor: isset($data['updateAuthor']) ? User::make($data['updateAuthor']) : null,
+            jsdPublic: $data['jsdPublic'] ?? true,
+            visibility: $data['visibility'] ?? [],
+        );
     }
 
     public function getId(): string
@@ -190,15 +164,15 @@ final class Comment implements ApiResponse
     public function toArray(): array
     {
         return [
-            self::ID => $this->id,
-            self::BODY => $this->body,
-            self::CREATED => $this->created,
-            self::UPDATED => $this->updated,
-            self::SELF => $this->self,
-            self::AUTHOR => $this->author?->toArray(),
-            self::UPDATE_AUTHOR => $this->updateAuthor?->toArray(),
-            self::JSD_PUBLIC => $this->jsdPublic,
-            self::VISIBILITY => $this->visibility,
+            'id' => $this->id,
+            'body' => $this->body,
+            'created' => $this->created,
+            'updated' => $this->updated,
+            'self' => $this->self,
+            'author' => $this->author?->toArray(),
+            'updateAuthor' => $this->updateAuthor?->toArray(),
+            'jsdPublic' => $this->jsdPublic,
+            'visibility' => $this->visibility,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Comments.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Comments.php
@@ -2,16 +2,14 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Comments extends Model
+use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;
+
+final class Comments extends Model implements Paginated
 {
+    use HasPagination;
+
     /** @var array<int, Comment> */
     private array $comments = [];
-
-    private int $total = 0;
-
-    private int $maxResults = 0;
-
-    private int $startAt = 0;
 
     private function __construct() {}
 
@@ -22,9 +20,7 @@ final class Comments extends Model
     {
         $model = new self;
 
-        $model->total = $data['total'] ?? 0;
-        $model->maxResults = $data['maxResults'] ?? 0;
-        $model->startAt = $data['startAt'] ?? 0;
+        $model->hydratePagination($data);
         $model->comments = array_map(
             fn (array $item) => Comment::make($item),
             $data['comments'] ?? []
@@ -41,42 +37,6 @@ final class Comments extends Model
         return $this->comments;
     }
 
-    public function getTotal(): int
-    {
-        return $this->total;
-    }
-
-    public function getMaxResults(): int
-    {
-        return $this->maxResults;
-    }
-
-    public function getStartAt(): int
-    {
-        return $this->startAt;
-    }
-
-    public function setTotal(int $value): self
-    {
-        $this->total = $value;
-
-        return $this;
-    }
-
-    public function setMaxResults(int $value): self
-    {
-        $this->maxResults = $value;
-
-        return $this;
-    }
-
-    public function setStartAt(int $value): self
-    {
-        $this->startAt = $value;
-
-        return $this;
-    }
-
     /**
      * @return array<string, mixed>
      */
@@ -84,9 +44,7 @@ final class Comments extends Model
     {
         return [
             'comments' => array_map(fn (Comment $c) => $c->toArray(), $this->comments),
-            'total' => $this->total,
-            'maxResults' => $this->maxResults,
-            'startAt' => $this->startAt,
+            ...$this->paginationToArray(),
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Comments.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Comments.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Comments extends Model
+{
+    /** @var array<int, Comment> */
+    private array $comments = [];
+
+    private int $total = 0;
+
+    private int $maxResults = 0;
+
+    private int $startAt = 0;
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->total = $data['total'] ?? 0;
+        $model->maxResults = $data['maxResults'] ?? 0;
+        $model->startAt = $data['startAt'] ?? 0;
+        $model->comments = array_map(
+            fn (array $item) => Comment::make($item),
+            $data['comments'] ?? []
+        );
+
+        return $model;
+    }
+
+    /**
+     * @return array<int, Comment>
+     */
+    public function getComments(): array
+    {
+        return $this->comments;
+    }
+
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    public function getMaxResults(): int
+    {
+        return $this->maxResults;
+    }
+
+    public function getStartAt(): int
+    {
+        return $this->startAt;
+    }
+
+    public function setTotal(int $value): self
+    {
+        $this->total = $value;
+
+        return $this;
+    }
+
+    public function setMaxResults(int $value): self
+    {
+        $this->maxResults = $value;
+
+        return $this;
+    }
+
+    public function setStartAt(int $value): self
+    {
+        $this->startAt = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'comments' => array_map(fn (Comment $c) => $c->toArray(), $this->comments),
+            'total' => $this->total,
+            'maxResults' => $this->maxResults,
+            'startAt' => $this->startAt,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Concerns/HasPagination.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Concerns/HasPagination.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models\Concerns;
+
+trait HasPagination
+{
+    private int $total = 0;
+
+    private int $maxResults = 0;
+
+    private int $startAt = 0;
+
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    public function getMaxResults(): int
+    {
+        return $this->maxResults;
+    }
+
+    public function getStartAt(): int
+    {
+        return $this->startAt;
+    }
+
+    public function setTotal(int $value): static
+    {
+        $this->total = $value;
+
+        return $this;
+    }
+
+    public function setMaxResults(int $value): static
+    {
+        $this->maxResults = $value;
+
+        return $this;
+    }
+
+    public function setStartAt(int $value): static
+    {
+        $this->startAt = $value;
+
+        return $this;
+    }
+
+    public function hasMore(): bool
+    {
+        return ($this->startAt + $this->maxResults) < $this->total;
+    }
+
+    public function getNextStartAt(): int
+    {
+        return $this->startAt + $this->maxResults;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    protected function hydratePagination(array $data): void
+    {
+        $this->total = $data['total'] ?? 0;
+        $this->maxResults = $data['maxResults'] ?? 0;
+        $this->startAt = $data['startAt'] ?? 0;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    protected function paginationToArray(): array
+    {
+        return [
+            'total' => $this->total,
+            'maxResults' => $this->maxResults,
+            'startAt' => $this->startAt,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Field.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Field.php
@@ -2,72 +2,43 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Field implements ApiResponse
+final class Field extends Model
 {
-    const CLAUSENAMES = 'clauseNames';
-
-    const SEARCHABLE = 'searchable';
-
-    const NAVIGABLE = 'navigable';
-
-    const ORDERABLE = 'orderable';
-
-    const SCHEMA = 'schema';
-
-    const SCOPE = 'scope';
-
-    const CUSTOM = 'custom';
-
-    const NAME = 'name';
-
-    const KEY = 'key';
-
-    const ID = 'id';
-
-    private string $key = '';
-
-    private string $id = '';
-
-    private string $name = '';
-
-    private bool $custom = false;
-
-    private bool $orderable = false;
-
-    private bool $navigable = false;
-
-    private bool $searchable = false;
-
-    /** @var array<string> */
-    private array $clauseNames = [];
-
-    /** @var array<string, mixed> */
-    private array $schema = [];
-
-    /** @var array<string, mixed> */
-    private array $scope = [];
-
-    private function __construct() {}
+    /**
+     * @param  array<string>  $clauseNames
+     * @param  array<string, mixed>  $schema
+     * @param  array<string, mixed>  $scope
+     */
+    private function __construct(
+        private string $key = '',
+        private string $id = '',
+        private string $name = '',
+        private bool $custom = false,
+        private bool $orderable = false,
+        private bool $navigable = false,
+        private bool $searchable = false,
+        private array $clauseNames = [],
+        private array $schema = [],
+        private array $scope = [],
+    ) {}
 
     /**
      * @param  array<string, mixed>  $data
      */
     public static function make(array $data = []): self
     {
-        $model = new self;
-
-        $model->setId($data[self::ID] ?? '');
-        $model->setKey($data[self::KEY] ?? '');
-        $model->setName($data[self::NAME] ?? '');
-        $model->setCustom($data[self::CUSTOM] ?? false);
-        $model->setSearchable($data[self::SEARCHABLE] ?? false);
-        $model->setOrderable($data[self::ORDERABLE] ?? false);
-        $model->setNavigable($data[self::NAVIGABLE] ?? false);
-        $model->setSchema($data[self::SCHEMA] ?? []);
-        $model->setClauseNames($data[self::CLAUSENAMES] ?? []);
-        $model->setScope($data[self::SCOPE] ?? []);
-
-        return $model;
+        return new self(
+            id: $data['id'] ?? '',
+            key: $data['key'] ?? '',
+            name: $data['name'] ?? '',
+            custom: $data['custom'] ?? false,
+            searchable: $data['searchable'] ?? false,
+            orderable: $data['orderable'] ?? false,
+            navigable: $data['navigable'] ?? false,
+            schema: $data['schema'] ?? [],
+            clauseNames: $data['clauseNames'] ?? [],
+            scope: $data['scope'] ?? [],
+        );
     }
 
     public function getId(): string
@@ -214,16 +185,16 @@ final class Field implements ApiResponse
     public function toArray(): array
     {
         return [
-            self::ID => $this->id,
-            self::KEY => $this->key,
-            self::NAME => $this->name,
-            self::CUSTOM => $this->custom,
-            self::ORDERABLE => $this->orderable,
-            self::NAVIGABLE => $this->navigable,
-            self::SEARCHABLE => $this->searchable,
-            self::CLAUSENAMES => $this->clauseNames,
-            self::SCHEMA => $this->schema,
-            self::SCOPE => $this->scope,
+            'id' => $this->id,
+            'key' => $this->key,
+            'name' => $this->name,
+            'custom' => $this->custom,
+            'orderable' => $this->orderable,
+            'navigable' => $this->navigable,
+            'searchable' => $this->searchable,
+            'clauseNames' => $this->clauseNames,
+            'schema' => $this->schema,
+            'scope' => $this->scope,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/FieldMeta.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/FieldMeta.php
@@ -2,52 +2,35 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class FieldMeta implements ApiResponse
+final class FieldMeta extends Model
 {
-    const FIELD_ID = 'fieldId';
-
-    const NAME = 'name';
-
-    const REQUIRED = 'required';
-
-    const SCHEMA = 'schema';
-
-    const OPERATIONS = 'operations';
-
-    const ALLOWED_VALUES = 'allowedValues';
-
-    private string $fieldId = '';
-
-    private string $name = '';
-
-    private bool $required = false;
-
-    /** @var array<string, mixed> */
-    private array $schema = [];
-
-    /** @var array<string> */
-    private array $operations = [];
-
-    /** @var array<mixed> */
-    private array $allowedValues = [];
-
-    private function __construct() {}
+    /**
+     * @param  array<string, mixed>  $schema
+     * @param  array<string>  $operations
+     * @param  array<mixed>  $allowedValues
+     */
+    private function __construct(
+        private string $fieldId = '',
+        private string $name = '',
+        private bool $required = false,
+        private array $schema = [],
+        private array $operations = [],
+        private array $allowedValues = [],
+    ) {}
 
     /**
      * @param  array<string, mixed>  $data
      */
     public static function make(array $data = []): self
     {
-        $model = new self;
-
-        $model->setFieldId($data[self::FIELD_ID] ?? '');
-        $model->setName($data[self::NAME] ?? '');
-        $model->setRequired($data[self::REQUIRED] ?? false);
-        $model->setSchema($data[self::SCHEMA] ?? []);
-        $model->setOperations($data[self::OPERATIONS] ?? []);
-        $model->setAllowedValues($data[self::ALLOWED_VALUES] ?? []);
-
-        return $model;
+        return new self(
+            fieldId: $data['fieldId'] ?? '',
+            name: $data['name'] ?? '',
+            required: $data['required'] ?? false,
+            schema: $data['schema'] ?? [],
+            operations: $data['operations'] ?? [],
+            allowedValues: $data['allowedValues'] ?? [],
+        );
     }
 
     public function getFieldId(): string
@@ -146,12 +129,12 @@ final class FieldMeta implements ApiResponse
     public function toArray(): array
     {
         return [
-            self::FIELD_ID => $this->fieldId,
-            self::NAME => $this->name,
-            self::REQUIRED => $this->required,
-            self::SCHEMA => $this->schema,
-            self::OPERATIONS => $this->operations,
-            self::ALLOWED_VALUES => $this->allowedValues,
+            'fieldId' => $this->fieldId,
+            'name' => $this->name,
+            'required' => $this->required,
+            'schema' => $this->schema,
+            'operations' => $this->operations,
+            'allowedValues' => $this->allowedValues,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/FieldMetas.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/FieldMetas.php
@@ -2,10 +2,8 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class FieldMetas implements ApiResponse
+final class FieldMetas extends Model
 {
-    const FIELDS = 'fields';
-
     /** @var array<int, FieldMeta> */
     private array $fields = [];
 
@@ -16,17 +14,12 @@ final class FieldMetas implements ApiResponse
      */
     public static function make(array $data = []): self
     {
-        $fields = [];
-
-        if (isset($data[self::FIELDS])) {
-            foreach ($data[self::FIELDS] as $item) {
-                $fields[] = FieldMeta::make($item);
-            }
-        }
-
         $model = new self;
 
-        $model->fields = $fields;
+        $model->fields = array_map(
+            fn (array $item) => FieldMeta::make($item),
+            $data['fields'] ?? []
+        );
 
         return $model;
     }

--- a/src/CaptureHigherEd/LaravelJira/Models/FieldMetas.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/FieldMetas.php
@@ -2,8 +2,12 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class FieldMetas extends Model
+use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;
+
+final class FieldMetas extends Model implements Paginated
 {
+    use HasPagination;
+
     /** @var array<int, FieldMeta> */
     private array $fields = [];
 
@@ -16,6 +20,7 @@ final class FieldMetas extends Model
     {
         $model = new self;
 
+        $model->hydratePagination($data);
         $model->fields = array_map(
             fn (array $item) => FieldMeta::make($item),
             $data['fields'] ?? []
@@ -33,10 +38,13 @@ final class FieldMetas extends Model
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return array<string, mixed>
      */
     public function toArray(): array
     {
-        return array_map(fn (FieldMeta $field) => $field->toArray(), $this->fields);
+        return [
+            'fields' => array_map(fn (FieldMeta $field) => $field->toArray(), $this->fields),
+            ...$this->paginationToArray(),
+        ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Fields.php
@@ -4,7 +4,7 @@ namespace CaptureHigherEd\LaravelJira\Models;
 
 use CaptureHigherEd\LaravelJira\Exception\CustomFieldDoesNotExistException;
 
-final class Fields implements ApiResponse
+final class Fields extends Model
 {
     /** @var array<int, Field> */
     private array $fields = [];
@@ -16,15 +16,9 @@ final class Fields implements ApiResponse
      */
     public static function make(array $data = []): self
     {
-        $fields = [];
-
-        foreach ($data as $item) {
-            $fields[] = Field::make($item);
-        }
-
         $model = new self;
 
-        $model->fields = $fields;
+        $model->fields = array_values(array_map(fn (array $item) => Field::make($item), $data));
 
         return $model;
     }

--- a/src/CaptureHigherEd/LaravelJira/Models/Issue.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Issue.php
@@ -2,7 +2,7 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Issue implements ApiResponse
+final class Issue extends Model
 {
     const KEY = 'key';
 

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueLink.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueLink.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class IssueLink extends Model
+{
+    /**
+     * @param  array<string, mixed>  $type
+     * @param  array<string, mixed>  $inwardIssue
+     * @param  array<string, mixed>  $outwardIssue
+     */
+    private function __construct(
+        private string $id = '',
+        private string $self = '',
+        private array $type = [],
+        private array $inwardIssue = [],
+        private array $outwardIssue = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        return new self(
+            id: $data['id'] ?? '',
+            self: $data['self'] ?? '',
+            type: $data['type'] ?? [],
+            inwardIssue: $data['inwardIssue'] ?? [],
+            outwardIssue: $data['outwardIssue'] ?? [],
+        );
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getType(): array
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getInwardIssue(): array
+    {
+        return $this->inwardIssue;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOutwardIssue(): array
+    {
+        return $this->outwardIssue;
+    }
+
+    public function setId(string $value): self
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public function setType(array $value): self
+    {
+        $this->type = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public function setInwardIssue(array $value): self
+    {
+        $this->inwardIssue = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     */
+    public function setOutwardIssue(array $value): self
+    {
+        $this->outwardIssue = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'self' => $this->self,
+            'type' => $this->type,
+            'inwardIssue' => $this->inwardIssue,
+            'outwardIssue' => $this->outwardIssue,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueLinkType.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueLinkType.php
@@ -2,18 +2,14 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Status extends Model
+final class IssueLinkType extends Model
 {
-    /**
-     * @param  array<string, mixed>  $statusCategory
-     */
     private function __construct(
         private string $id = '',
         private string $name = '',
-        private string $description = '',
-        private string $iconUrl = '',
+        private string $inward = '',
+        private string $outward = '',
         private string $self = '',
-        private array $statusCategory = [],
     ) {}
 
     /**
@@ -24,10 +20,9 @@ final class Status extends Model
         return new self(
             id: $data['id'] ?? '',
             name: $data['name'] ?? '',
-            description: $data['description'] ?? '',
-            iconUrl: $data['iconUrl'] ?? '',
+            inward: $data['inward'] ?? '',
+            outward: $data['outward'] ?? '',
             self: $data['self'] ?? '',
-            statusCategory: $data['statusCategory'] ?? [],
         );
     }
 
@@ -41,27 +36,19 @@ final class Status extends Model
         return $this->name;
     }
 
-    public function getDescription(): string
+    public function getInward(): string
     {
-        return $this->description;
+        return $this->inward;
     }
 
-    public function getIconUrl(): string
+    public function getOutward(): string
     {
-        return $this->iconUrl;
+        return $this->outward;
     }
 
     public function getSelf(): string
     {
         return $this->self;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function getStatusCategory(): array
-    {
-        return $this->statusCategory;
     }
 
     public function setId(string $value): self
@@ -78,16 +65,16 @@ final class Status extends Model
         return $this;
     }
 
-    public function setDescription(string $value): self
+    public function setInward(string $value): self
     {
-        $this->description = $value;
+        $this->inward = $value;
 
         return $this;
     }
 
-    public function setIconUrl(string $value): self
+    public function setOutward(string $value): self
     {
-        $this->iconUrl = $value;
+        $this->outward = $value;
 
         return $this;
     }
@@ -100,16 +87,6 @@ final class Status extends Model
     }
 
     /**
-     * @param  array<string, mixed>  $value
-     */
-    public function setStatusCategory(array $value): self
-    {
-        $this->statusCategory = $value;
-
-        return $this;
-    }
-
-    /**
      * @return array<string, mixed>
      */
     public function toArray(): array
@@ -117,10 +94,9 @@ final class Status extends Model
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'description' => $this->description,
-            'iconUrl' => $this->iconUrl,
+            'inward' => $this->inward,
+            'outward' => $this->outward,
             'self' => $this->self,
-            'statusCategory' => $this->statusCategory,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueLinkTypes.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueLinkTypes.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class IssueLinkTypes extends Model
+{
+    /** @var array<int, IssueLinkType> */
+    private array $types = [];
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->types = array_map(
+            fn (array $item) => IssueLinkType::make($item),
+            $data['issueLinkTypes'] ?? []
+        );
+
+        return $model;
+    }
+
+    /**
+     * @return array<int, IssueLinkType>
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        return array_map(fn (IssueLinkType $t) => $t->toArray(), $this->types);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueType.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueType.php
@@ -2,49 +2,30 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class IssueType implements ApiResponse
+final class IssueType extends Model
 {
-    const ID = 'id';
-
-    const NAME = 'name';
-
-    const DESCRIPTION = 'description';
-
-    const SUBTASK = 'subtask';
-
-    const ICON_URL = 'iconUrl';
-
-    const SELF = 'self';
-
-    private string $id = '';
-
-    private string $name = '';
-
-    private string $description = '';
-
-    private bool $subtask = false;
-
-    private string $iconUrl = '';
-
-    private string $self = '';
-
-    private function __construct() {}
+    private function __construct(
+        private string $id = '',
+        private string $name = '',
+        private string $description = '',
+        private bool $subtask = false,
+        private string $iconUrl = '',
+        private string $self = '',
+    ) {}
 
     /**
      * @param  array<string, mixed>  $data
      */
     public static function make(array $data = []): self
     {
-        $model = new self;
-
-        $model->setId($data[self::ID] ?? '');
-        $model->setName($data[self::NAME] ?? '');
-        $model->setDescription($data[self::DESCRIPTION] ?? '');
-        $model->setSubtask($data[self::SUBTASK] ?? false);
-        $model->setIconUrl($data[self::ICON_URL] ?? '');
-        $model->setSelf($data[self::SELF] ?? '');
-
-        return $model;
+        return new self(
+            id: $data['id'] ?? '',
+            name: $data['name'] ?? '',
+            description: $data['description'] ?? '',
+            subtask: $data['subtask'] ?? false,
+            iconUrl: $data['iconUrl'] ?? '',
+            self: $data['self'] ?? '',
+        );
     }
 
     public function getId(): string
@@ -125,12 +106,12 @@ final class IssueType implements ApiResponse
     public function toArray(): array
     {
         return [
-            self::ID => $this->id,
-            self::NAME => $this->name,
-            self::DESCRIPTION => $this->description,
-            self::SUBTASK => $this->subtask,
-            self::ICON_URL => $this->iconUrl,
-            self::SELF => $this->self,
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'subtask' => $this->subtask,
+            'iconUrl' => $this->iconUrl,
+            'self' => $this->self,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueTypes.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueTypes.php
@@ -2,8 +2,12 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class IssueTypes extends Model
+use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;
+
+final class IssueTypes extends Model implements Paginated
 {
+    use HasPagination;
+
     /** @var array<int, IssueType> */
     private array $issueTypes = [];
 
@@ -16,6 +20,7 @@ final class IssueTypes extends Model
     {
         $model = new self;
 
+        $model->hydratePagination($data);
         $model->issueTypes = array_map(
             fn (array $item) => IssueType::make($item),
             $data['issueTypes'] ?? []
@@ -33,10 +38,13 @@ final class IssueTypes extends Model
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return array<string, mixed>
      */
     public function toArray(): array
     {
-        return array_map(fn (IssueType $issueType) => $issueType->toArray(), $this->issueTypes);
+        return [
+            'issueTypes' => array_map(fn (IssueType $issueType) => $issueType->toArray(), $this->issueTypes),
+            ...$this->paginationToArray(),
+        ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueTypes.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueTypes.php
@@ -2,10 +2,8 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class IssueTypes implements ApiResponse
+final class IssueTypes extends Model
 {
-    const ISSUE_TYPES = 'issueTypes';
-
     /** @var array<int, IssueType> */
     private array $issueTypes = [];
 
@@ -16,17 +14,12 @@ final class IssueTypes implements ApiResponse
      */
     public static function make(array $data = []): self
     {
-        $issueTypes = [];
-
-        if (isset($data[self::ISSUE_TYPES])) {
-            foreach ($data[self::ISSUE_TYPES] as $item) {
-                $issueTypes[] = IssueType::make($item);
-            }
-        }
-
         $model = new self;
 
-        $model->issueTypes = $issueTypes;
+        $model->issueTypes = array_map(
+            fn (array $item) => IssueType::make($item),
+            $data['issueTypes'] ?? []
+        );
 
         return $model;
     }

--- a/src/CaptureHigherEd/LaravelJira/Models/Model.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Model.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+abstract class Model implements ApiResponse {}

--- a/src/CaptureHigherEd/LaravelJira/Models/Paginated.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Paginated.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+interface Paginated
+{
+    public function getTotal(): int;
+
+    public function getMaxResults(): int;
+
+    public function getStartAt(): int;
+
+    public function setTotal(int $value): static;
+
+    public function setMaxResults(int $value): static;
+
+    public function setStartAt(int $value): static;
+
+    public function hasMore(): bool;
+
+    public function getNextStartAt(): int;
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Priority.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Priority.php
@@ -2,59 +2,34 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Priority implements ApiResponse
+final class Priority extends Model
 {
-    const ID = 'id';
-
-    const NAME = 'name';
-
-    const DESCRIPTION = 'description';
-
-    const ICON_URL = 'iconUrl';
-
-    const SELF = 'self';
-
-    const STATUS_COLOR = 'statusColor';
-
-    const IS_DEFAULT = 'isDefault';
-
-    const AVATAR_ID = 'avatarId';
-
-    private string $id = '';
-
-    private string $name = '';
-
-    private string $description = '';
-
-    private string $iconUrl = '';
-
-    private string $self = '';
-
-    private string $statusColor = '';
-
-    private bool $isDefault = false;
-
-    private int $avatarId = 0;
-
-    private function __construct() {}
+    private function __construct(
+        private string $id = '',
+        private string $name = '',
+        private string $description = '',
+        private string $iconUrl = '',
+        private string $self = '',
+        private string $statusColor = '',
+        private bool $isDefault = false,
+        private int $avatarId = 0,
+    ) {}
 
     /**
      * @param  array<string, mixed>  $data
      */
     public static function make(array $data = []): self
     {
-        $model = new self;
-
-        $model->setId($data[self::ID] ?? '');
-        $model->setName($data[self::NAME] ?? '');
-        $model->setDescription($data[self::DESCRIPTION] ?? '');
-        $model->setIconUrl($data[self::ICON_URL] ?? '');
-        $model->setSelf($data[self::SELF] ?? '');
-        $model->setStatusColor($data[self::STATUS_COLOR] ?? '');
-        $model->setIsDefault($data[self::IS_DEFAULT] ?? false);
-        $model->setAvatarId((int) ($data[self::AVATAR_ID] ?? 0));
-
-        return $model;
+        return new self(
+            id: $data['id'] ?? '',
+            name: $data['name'] ?? '',
+            description: $data['description'] ?? '',
+            iconUrl: $data['iconUrl'] ?? '',
+            self: $data['self'] ?? '',
+            statusColor: $data['statusColor'] ?? '',
+            isDefault: $data['isDefault'] ?? false,
+            avatarId: (int) ($data['avatarId'] ?? 0),
+        );
     }
 
     public function getId(): string
@@ -159,14 +134,14 @@ final class Priority implements ApiResponse
     public function toArray(): array
     {
         return [
-            self::ID => $this->id,
-            self::NAME => $this->name,
-            self::DESCRIPTION => $this->description,
-            self::ICON_URL => $this->iconUrl,
-            self::SELF => $this->self,
-            self::STATUS_COLOR => $this->statusColor,
-            self::IS_DEFAULT => $this->isDefault,
-            self::AVATAR_ID => $this->avatarId,
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'iconUrl' => $this->iconUrl,
+            'self' => $this->self,
+            'statusColor' => $this->statusColor,
+            'isDefault' => $this->isDefault,
+            'avatarId' => $this->avatarId,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Project.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Project.php
@@ -2,55 +2,35 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Project implements ApiResponse
+final class Project extends Model
 {
-    const ID = 'id';
-
-    const KEY = 'key';
-
-    const NAME = 'name';
-
-    const SELF = 'self';
-
-    const PROJECT_TYPE_KEY = 'projectTypeKey';
-
-    const SIMPLIFIED = 'simplified';
-
-    const AVATAR_URLS = 'avatarUrls';
-
-    private string $id = '';
-
-    private string $key = '';
-
-    private string $name = '';
-
-    private string $self = '';
-
-    private string $projectTypeKey = '';
-
-    private bool $simplified = false;
-
-    /** @var array<string, string> */
-    private array $avatarUrls = [];
-
-    private function __construct() {}
+    /**
+     * @param  array<string, string>  $avatarUrls
+     */
+    private function __construct(
+        private string $id = '',
+        private string $key = '',
+        private string $name = '',
+        private string $self = '',
+        private string $projectTypeKey = '',
+        private bool $simplified = false,
+        private array $avatarUrls = [],
+    ) {}
 
     /**
      * @param  array<string, mixed>  $data
      */
     public static function make(array $data = []): self
     {
-        $model = new self;
-
-        $model->setId($data[self::ID] ?? '');
-        $model->setKey($data[self::KEY] ?? '');
-        $model->setName($data[self::NAME] ?? '');
-        $model->setSelf($data[self::SELF] ?? '');
-        $model->setProjectTypeKey($data[self::PROJECT_TYPE_KEY] ?? '');
-        $model->setSimplified($data[self::SIMPLIFIED] ?? false);
-        $model->setAvatarUrls($data[self::AVATAR_URLS] ?? []);
-
-        return $model;
+        return new self(
+            id: $data['id'] ?? '',
+            key: $data['key'] ?? '',
+            name: $data['name'] ?? '',
+            self: $data['self'] ?? '',
+            projectTypeKey: $data['projectTypeKey'] ?? '',
+            simplified: $data['simplified'] ?? false,
+            avatarUrls: $data['avatarUrls'] ?? [],
+        );
     }
 
     public function getId(): string
@@ -149,13 +129,13 @@ final class Project implements ApiResponse
     public function toArray(): array
     {
         return [
-            self::ID => $this->id,
-            self::KEY => $this->key,
-            self::NAME => $this->name,
-            self::SELF => $this->self,
-            self::PROJECT_TYPE_KEY => $this->projectTypeKey,
-            self::SIMPLIFIED => $this->simplified,
-            self::AVATAR_URLS => $this->avatarUrls,
+            'id' => $this->id,
+            'key' => $this->key,
+            'name' => $this->name,
+            'self' => $this->self,
+            'projectTypeKey' => $this->projectTypeKey,
+            'simplified' => $this->simplified,
+            'avatarUrls' => $this->avatarUrls,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Projects.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Projects.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Projects extends Model
+{
+    /** @var array<int, Project> */
+    private array $projects = [];
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->projects = array_values(array_map(fn (array $item) => Project::make($item), $data));
+
+        return $model;
+    }
+
+    /**
+     * @return array<int, Project>
+     */
+    public function getProjects(): array
+    {
+        return $this->projects;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        return array_map(fn (Project $p) => $p->toArray(), $this->projects);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Resolution.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Resolution.php
@@ -2,39 +2,26 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Resolution implements ApiResponse
+final class Resolution extends Model
 {
-    const ID = 'id';
-
-    const NAME = 'name';
-
-    const DESCRIPTION = 'description';
-
-    const SELF = 'self';
-
-    private string $id = '';
-
-    private string $name = '';
-
-    private string $description = '';
-
-    private string $self = '';
-
-    private function __construct() {}
+    private function __construct(
+        private string $id = '',
+        private string $name = '',
+        private string $description = '',
+        private string $self = '',
+    ) {}
 
     /**
      * @param  array<string, mixed>  $data
      */
     public static function make(array $data = []): self
     {
-        $model = new self;
-
-        $model->setId($data[self::ID] ?? '');
-        $model->setName($data[self::NAME] ?? '');
-        $model->setDescription($data[self::DESCRIPTION] ?? '');
-        $model->setSelf($data[self::SELF] ?? '');
-
-        return $model;
+        return new self(
+            id: $data['id'] ?? '',
+            name: $data['name'] ?? '',
+            description: $data['description'] ?? '',
+            self: $data['self'] ?? '',
+        );
     }
 
     public function getId(): string
@@ -91,10 +78,10 @@ final class Resolution implements ApiResponse
     public function toArray(): array
     {
         return [
-            self::ID => $this->id,
-            self::NAME => $this->name,
-            self::DESCRIPTION => $this->description,
-            self::SELF => $this->self,
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'self' => $this->self,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Search.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Search.php
@@ -2,10 +2,8 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Search implements ApiResponse
+final class Search extends Model
 {
-    const ISSUES = 'issues';
-
     /** @var array<int, Issue> */
     private array $issues = [];
 
@@ -16,17 +14,12 @@ final class Search implements ApiResponse
      */
     public static function make(array $data = []): self
     {
-        $issues = [];
-
-        if (isset($data[self::ISSUES])) {
-            foreach ($data[self::ISSUES] as $item) {
-                $issues[] = Issue::make($item);
-            }
-        }
-
         $model = new self;
 
-        $model->issues = $issues;
+        $model->issues = array_map(
+            fn (array $item) => Issue::make($item),
+            $data['issues'] ?? []
+        );
 
         return $model;
     }
@@ -45,7 +38,7 @@ final class Search implements ApiResponse
     public function toArray(): array
     {
         return [
-            self::ISSUES => array_map(fn (Issue $issue) => $issue->toArray(), $this->issues),
+            'issues' => array_map(fn (Issue $issue) => $issue->toArray(), $this->issues),
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Search.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Search.php
@@ -2,8 +2,12 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Search extends Model
+use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;
+
+final class Search extends Model implements Paginated
 {
+    use HasPagination;
+
     /** @var array<int, Issue> */
     private array $issues = [];
 
@@ -16,6 +20,7 @@ final class Search extends Model
     {
         $model = new self;
 
+        $model->hydratePagination($data);
         $model->issues = array_map(
             fn (array $item) => Issue::make($item),
             $data['issues'] ?? []
@@ -39,6 +44,7 @@ final class Search extends Model
     {
         return [
             'issues' => array_map(fn (Issue $issue) => $issue->toArray(), $this->issues),
+            ...$this->paginationToArray(),
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Transition.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Transition.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Transition extends Model
+{
+    private function __construct(
+        private string $id = '',
+        private string $name = '',
+        private ?Status $to = null,
+        private bool $hasScreen = false,
+        private bool $isGlobal = false,
+        private bool $isInitial = false,
+        private bool $isConditional = false,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        return new self(
+            id: $data['id'] ?? '',
+            name: $data['name'] ?? '',
+            to: isset($data['to']) ? Status::make($data['to']) : null,
+            hasScreen: $data['hasScreen'] ?? false,
+            isGlobal: $data['isGlobal'] ?? false,
+            isInitial: $data['isInitial'] ?? false,
+            isConditional: $data['isConditional'] ?? false,
+        );
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getTo(): ?Status
+    {
+        return $this->to;
+    }
+
+    public function getHasScreen(): bool
+    {
+        return $this->hasScreen;
+    }
+
+    public function getIsGlobal(): bool
+    {
+        return $this->isGlobal;
+    }
+
+    public function getIsInitial(): bool
+    {
+        return $this->isInitial;
+    }
+
+    public function getIsConditional(): bool
+    {
+        return $this->isConditional;
+    }
+
+    public function setId(string $value): self
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    public function setName(string $value): self
+    {
+        $this->name = $value;
+
+        return $this;
+    }
+
+    public function setTo(?Status $value): self
+    {
+        $this->to = $value;
+
+        return $this;
+    }
+
+    public function setHasScreen(bool $value): self
+    {
+        $this->hasScreen = $value;
+
+        return $this;
+    }
+
+    public function setIsGlobal(bool $value): self
+    {
+        $this->isGlobal = $value;
+
+        return $this;
+    }
+
+    public function setIsInitial(bool $value): self
+    {
+        $this->isInitial = $value;
+
+        return $this;
+    }
+
+    public function setIsConditional(bool $value): self
+    {
+        $this->isConditional = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'to' => $this->to?->toArray(),
+            'hasScreen' => $this->hasScreen,
+            'isGlobal' => $this->isGlobal,
+            'isInitial' => $this->isInitial,
+            'isConditional' => $this->isConditional,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Transitions.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Transitions.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Transitions extends Model
+{
+    /** @var array<int, Transition> */
+    private array $transitions = [];
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->transitions = array_map(
+            fn (array $item) => Transition::make($item),
+            $data['transitions'] ?? []
+        );
+
+        return $model;
+    }
+
+    /**
+     * @return array<int, Transition>
+     */
+    public function getTransitions(): array
+    {
+        return $this->transitions;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        return array_map(fn (Transition $t) => $t->toArray(), $this->transitions);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/User.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/User.php
@@ -2,65 +2,39 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class User implements ApiResponse
+final class User extends Model
 {
-    const NAME = 'displayName';
-
-    const KEY = 'accountId';
-
-    const EMAIL = 'emailAddress';
-
-    const ACTIVE = 'active';
-
-    const SELF = 'self';
-
-    const ACCOUNT_TYPE = 'accountType';
-
-    const TIME_ZONE = 'timeZone';
-
-    const LOCALE = 'locale';
-
-    const AVATAR_URLS = 'avatarUrls';
-
-    private string $key = '';
-
-    private string $email = '';
-
-    private bool $active = false;
-
-    private string $name = '';
-
-    private string $self = '';
-
-    private string $accountType = '';
-
-    private string $timeZone = '';
-
-    private string $locale = '';
-
-    /** @var array<string, string> */
-    private array $avatarUrls = [];
-
-    private function __construct() {}
+    /**
+     * @param  array<string, string>  $avatarUrls
+     */
+    private function __construct(
+        private string $key = '',
+        private string $email = '',
+        private bool $active = false,
+        private string $name = '',
+        private string $self = '',
+        private string $accountType = '',
+        private string $timeZone = '',
+        private string $locale = '',
+        private array $avatarUrls = [],
+    ) {}
 
     /**
      * @param  array<string, mixed>  $data
      */
     public static function make(array $data = []): self
     {
-        $model = new self;
-
-        $model->setKey($data[self::KEY] ?? '');
-        $model->setName($data[self::NAME] ?? '');
-        $model->setEmail($data[self::EMAIL] ?? '');
-        $model->setActive($data[self::ACTIVE] ?? false);
-        $model->setSelf($data[self::SELF] ?? '');
-        $model->setAccountType($data[self::ACCOUNT_TYPE] ?? '');
-        $model->setTimeZone($data[self::TIME_ZONE] ?? '');
-        $model->setLocale($data[self::LOCALE] ?? '');
-        $model->setAvatarUrls($data[self::AVATAR_URLS] ?? []);
-
-        return $model;
+        return new self(
+            key: $data['accountId'] ?? '',
+            email: $data['emailAddress'] ?? '',
+            active: $data['active'] ?? false,
+            name: $data['displayName'] ?? '',
+            self: $data['self'] ?? '',
+            accountType: $data['accountType'] ?? '',
+            timeZone: $data['timeZone'] ?? '',
+            locale: $data['locale'] ?? '',
+            avatarUrls: $data['avatarUrls'] ?? [],
+        );
     }
 
     public function getKey(): string
@@ -183,15 +157,15 @@ final class User implements ApiResponse
     public function toArray(): array
     {
         return [
-            self::KEY => $this->key,
-            self::NAME => $this->name,
-            self::EMAIL => $this->email,
-            self::ACTIVE => $this->active,
-            self::SELF => $this->self,
-            self::ACCOUNT_TYPE => $this->accountType,
-            self::TIME_ZONE => $this->timeZone,
-            self::LOCALE => $this->locale,
-            self::AVATAR_URLS => $this->avatarUrls,
+            'accountId' => $this->key,
+            'displayName' => $this->name,
+            'emailAddress' => $this->email,
+            'active' => $this->active,
+            'self' => $this->self,
+            'accountType' => $this->accountType,
+            'timeZone' => $this->timeZone,
+            'locale' => $this->locale,
+            'avatarUrls' => $this->avatarUrls,
         ];
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Users.php
@@ -2,7 +2,7 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Users implements ApiResponse
+final class Users extends Model
 {
     /** @var array<int, User> */
     private array $users = [];
@@ -14,15 +14,9 @@ final class Users implements ApiResponse
      */
     public static function make(array $data = []): self
     {
-        $users = [];
-
-        foreach ($data as $item) {
-            $users[] = User::make($item);
-        }
-
         $model = new self;
 
-        $model->users = $users;
+        $model->users = array_values(array_map(fn (array $item) => User::make($item), $data));
 
         return $model;
     }

--- a/src/CaptureHigherEd/LaravelJira/Models/Watchers.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Watchers.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Watchers extends Model
+{
+    /** @var array<int, User> */
+    private array $watchers = [];
+
+    private string $self = '';
+
+    private bool $isWatching = false;
+
+    private int $watchCount = 0;
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->self = $data['self'] ?? '';
+        $model->isWatching = $data['isWatching'] ?? false;
+        $model->watchCount = $data['watchCount'] ?? 0;
+        $model->watchers = array_map(
+            fn (array $item) => User::make($item),
+            $data['watchers'] ?? []
+        );
+
+        return $model;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    public function getIsWatching(): bool
+    {
+        return $this->isWatching;
+    }
+
+    public function getWatchCount(): int
+    {
+        return $this->watchCount;
+    }
+
+    /**
+     * @return array<int, User>
+     */
+    public function getWatchers(): array
+    {
+        return $this->watchers;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    public function setIsWatching(bool $value): self
+    {
+        $this->isWatching = $value;
+
+        return $this;
+    }
+
+    public function setWatchCount(int $value): self
+    {
+        $this->watchCount = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'self' => $this->self,
+            'isWatching' => $this->isWatching,
+            'watchCount' => $this->watchCount,
+            'watchers' => array_map(fn (User $u) => $u->toArray(), $this->watchers),
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Worklog.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Worklog.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Worklog extends Model
+{
+    /**
+     * @param  array<mixed>  $comment
+     */
+    private function __construct(
+        private string $id = '',
+        private string $self = '',
+        private ?User $author = null,
+        private ?User $updateAuthor = null,
+        private array $comment = [],
+        private string $started = '',
+        private string $timeSpent = '',
+        private int $timeSpentSeconds = 0,
+        private string $issueId = '',
+        private string $created = '',
+        private string $updated = '',
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        return new self(
+            id: $data['id'] ?? '',
+            self: $data['self'] ?? '',
+            author: isset($data['author']) ? User::make($data['author']) : null,
+            updateAuthor: isset($data['updateAuthor']) ? User::make($data['updateAuthor']) : null,
+            comment: $data['comment'] ?? [],
+            started: $data['started'] ?? '',
+            timeSpent: $data['timeSpent'] ?? '',
+            timeSpentSeconds: (int) ($data['timeSpentSeconds'] ?? 0),
+            issueId: $data['issueId'] ?? '',
+            created: $data['created'] ?? '',
+            updated: $data['updated'] ?? '',
+        );
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getSelf(): string
+    {
+        return $this->self;
+    }
+
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function getUpdateAuthor(): ?User
+    {
+        return $this->updateAuthor;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getComment(): array
+    {
+        return $this->comment;
+    }
+
+    public function getStarted(): string
+    {
+        return $this->started;
+    }
+
+    public function getTimeSpent(): string
+    {
+        return $this->timeSpent;
+    }
+
+    public function getTimeSpentSeconds(): int
+    {
+        return $this->timeSpentSeconds;
+    }
+
+    public function getIssueId(): string
+    {
+        return $this->issueId;
+    }
+
+    public function getCreated(): string
+    {
+        return $this->created;
+    }
+
+    public function getUpdated(): string
+    {
+        return $this->updated;
+    }
+
+    public function setId(string $value): self
+    {
+        $this->id = $value;
+
+        return $this;
+    }
+
+    public function setSelf(string $value): self
+    {
+        $this->self = $value;
+
+        return $this;
+    }
+
+    public function setAuthor(?User $value): self
+    {
+        $this->author = $value;
+
+        return $this;
+    }
+
+    public function setUpdateAuthor(?User $value): self
+    {
+        $this->updateAuthor = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<mixed>  $value
+     */
+    public function setComment(array $value): self
+    {
+        $this->comment = $value;
+
+        return $this;
+    }
+
+    public function setStarted(string $value): self
+    {
+        $this->started = $value;
+
+        return $this;
+    }
+
+    public function setTimeSpent(string $value): self
+    {
+        $this->timeSpent = $value;
+
+        return $this;
+    }
+
+    public function setTimeSpentSeconds(int $value): self
+    {
+        $this->timeSpentSeconds = $value;
+
+        return $this;
+    }
+
+    public function setIssueId(string $value): self
+    {
+        $this->issueId = $value;
+
+        return $this;
+    }
+
+    public function setCreated(string $value): self
+    {
+        $this->created = $value;
+
+        return $this;
+    }
+
+    public function setUpdated(string $value): self
+    {
+        $this->updated = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'self' => $this->self,
+            'author' => $this->author?->toArray(),
+            'updateAuthor' => $this->updateAuthor?->toArray(),
+            'comment' => $this->comment,
+            'started' => $this->started,
+            'timeSpent' => $this->timeSpent,
+            'timeSpentSeconds' => $this->timeSpentSeconds,
+            'issueId' => $this->issueId,
+            'created' => $this->created,
+            'updated' => $this->updated,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Worklogs.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Worklogs.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Models;
+
+final class Worklogs extends Model
+{
+    /** @var array<int, Worklog> */
+    private array $worklogs = [];
+
+    private int $total = 0;
+
+    private int $maxResults = 0;
+
+    private int $startAt = 0;
+
+    private function __construct() {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function make(array $data = []): self
+    {
+        $model = new self;
+
+        $model->total = $data['total'] ?? 0;
+        $model->maxResults = $data['maxResults'] ?? 0;
+        $model->startAt = $data['startAt'] ?? 0;
+        $model->worklogs = array_map(
+            fn (array $item) => Worklog::make($item),
+            $data['worklogs'] ?? []
+        );
+
+        return $model;
+    }
+
+    /**
+     * @return array<int, Worklog>
+     */
+    public function getWorklogs(): array
+    {
+        return $this->worklogs;
+    }
+
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    public function getMaxResults(): int
+    {
+        return $this->maxResults;
+    }
+
+    public function getStartAt(): int
+    {
+        return $this->startAt;
+    }
+
+    public function setTotal(int $value): self
+    {
+        $this->total = $value;
+
+        return $this;
+    }
+
+    public function setMaxResults(int $value): self
+    {
+        $this->maxResults = $value;
+
+        return $this;
+    }
+
+    public function setStartAt(int $value): self
+    {
+        $this->startAt = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'worklogs' => array_map(fn (Worklog $w) => $w->toArray(), $this->worklogs),
+            'total' => $this->total,
+            'maxResults' => $this->maxResults,
+            'startAt' => $this->startAt,
+        ];
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Models/Worklogs.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Worklogs.php
@@ -2,16 +2,14 @@
 
 namespace CaptureHigherEd\LaravelJira\Models;
 
-final class Worklogs extends Model
+use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;
+
+final class Worklogs extends Model implements Paginated
 {
+    use HasPagination;
+
     /** @var array<int, Worklog> */
     private array $worklogs = [];
-
-    private int $total = 0;
-
-    private int $maxResults = 0;
-
-    private int $startAt = 0;
 
     private function __construct() {}
 
@@ -22,9 +20,7 @@ final class Worklogs extends Model
     {
         $model = new self;
 
-        $model->total = $data['total'] ?? 0;
-        $model->maxResults = $data['maxResults'] ?? 0;
-        $model->startAt = $data['startAt'] ?? 0;
+        $model->hydratePagination($data);
         $model->worklogs = array_map(
             fn (array $item) => Worklog::make($item),
             $data['worklogs'] ?? []
@@ -41,42 +37,6 @@ final class Worklogs extends Model
         return $this->worklogs;
     }
 
-    public function getTotal(): int
-    {
-        return $this->total;
-    }
-
-    public function getMaxResults(): int
-    {
-        return $this->maxResults;
-    }
-
-    public function getStartAt(): int
-    {
-        return $this->startAt;
-    }
-
-    public function setTotal(int $value): self
-    {
-        $this->total = $value;
-
-        return $this;
-    }
-
-    public function setMaxResults(int $value): self
-    {
-        $this->maxResults = $value;
-
-        return $this;
-    }
-
-    public function setStartAt(int $value): self
-    {
-        $this->startAt = $value;
-
-        return $this;
-    }
-
     /**
      * @return array<string, mixed>
      */
@@ -84,9 +44,7 @@ final class Worklogs extends Model
     {
         return [
             'worklogs' => array_map(fn (Worklog $w) => $w->toArray(), $this->worklogs),
-            'total' => $this->total,
-            'maxResults' => $this->maxResults,
-            'startAt' => $this->startAt,
+            ...$this->paginationToArray(),
         ];
     }
 }

--- a/tests/Api/AttachmentsTest.php
+++ b/tests/Api/AttachmentsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Api;
+
+use CaptureHigherEd\LaravelJira\Api\Attachments;
+use CaptureHigherEd\LaravelJira\Models\Attachment;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use PHPUnit\Framework\TestCase;
+
+class AttachmentsTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    public function test_show(): void
+    {
+        $response = $this->jsonResponse([
+            'id' => '10001',
+            'filename' => 'screenshot.png',
+            'mimeType' => 'image/png',
+            'size' => 4096,
+            'content' => 'https://example.atlassian.net/secure/attachment/10001/screenshot.png',
+            'self' => 'https://example.atlassian.net/rest/api/3/attachment/10001',
+            'created' => '2024-01-01T09:00:00.000+0000',
+            'thumbnail' => '',
+        ]);
+        $client = $this->mockClientExpecting('GET', 'attachment/10001', ['query' => []], $response);
+        $api = new Attachments($client);
+
+        $result = $api->show('10001');
+
+        $this->assertInstanceOf(Attachment::class, $result, 'Attachments::show() should return an Attachment instance');
+        $this->assertSame('10001', $result->getId(), 'Attachments::show() should return the attachment with the correct ID');
+        $this->assertSame('screenshot.png', $result->getFilename(), 'Attachments::show() should hydrate the filename correctly');
+    }
+
+    public function test_delete(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('DELETE', 'attachment/10001', ['query' => []], $response);
+        $api = new Attachments($client);
+
+        $result = $api->delete('10001');
+
+        $this->assertSame([], $result, 'Attachments::delete() should return an empty array for a successful 204 No Content response');
+    }
+
+    public function test_get_meta(): void
+    {
+        $meta = ['enabled' => true, 'uploadLimit' => 10485760];
+        $response = $this->jsonResponse($meta);
+        $client = $this->mockClientExpecting('GET', 'attachment/meta', ['query' => []], $response);
+        $api = new Attachments($client);
+
+        $result = $api->getMeta();
+
+        $this->assertSame($meta, $result, 'Attachments::getMeta() should return the raw metadata array from the API response');
+    }
+}

--- a/tests/Api/CommentsTest.php
+++ b/tests/Api/CommentsTest.php
@@ -78,4 +78,18 @@ class CommentsTest extends TestCase
 
         $this->assertSame([], $result, 'Comments::delete() should return an empty array for a successful 204 No Content response');
     }
+
+    public function test_paginate(): void
+    {
+        $page1 = $this->jsonResponse(['comments' => [], 'total' => 2, 'maxResults' => 1, 'startAt' => 0]);
+        $page2 = $this->jsonResponse(['comments' => [], 'total' => 2, 'maxResults' => 1, 'startAt' => 1]);
+        $client = $this->mockClientWithResponses([$page1, $page2]);
+        $api = new Comments($client);
+
+        $pages = iterator_to_array($api->paginate('KEY-1'));
+
+        $this->assertCount(2, $pages, 'Comments::paginate() should yield one page per HTTP response');
+        $this->assertInstanceOf(ModelsComments::class, $pages[0], 'Each yielded value should be a ModelsComments instance');
+        $this->assertSame(2, $pages[0]->getTotal(), 'Total should be hydrated from the first page response');
+    }
 }

--- a/tests/Api/CommentsTest.php
+++ b/tests/Api/CommentsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Api;
+
+use CaptureHigherEd\LaravelJira\Api\Comments;
+use CaptureHigherEd\LaravelJira\Models\Comment;
+use CaptureHigherEd\LaravelJira\Models\Comments as ModelsComments;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use PHPUnit\Framework\TestCase;
+
+class CommentsTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    public function test_index(): void
+    {
+        $response = $this->jsonResponse([
+            'comments' => [
+                ['id' => '1', 'body' => [], 'created' => '', 'updated' => '', 'self' => '', 'jsdPublic' => true, 'visibility' => []],
+            ],
+            'total' => 1,
+            'maxResults' => 50,
+            'startAt' => 0,
+        ]);
+        $client = $this->mockClientExpecting('GET', 'issue/KEY-1/comment', ['query' => []], $response);
+        $api = new Comments($client);
+
+        $result = $api->index('KEY-1');
+
+        $this->assertInstanceOf(ModelsComments::class, $result, 'Comments::index() should return a ModelsComments instance');
+        $this->assertCount(1, $result->getComments(), 'Comments::index() should return exactly 1 comment from the response');
+        $this->assertSame(1, $result->getTotal(), 'Comments::index() should hydrate the total count correctly');
+    }
+
+    public function test_show(): void
+    {
+        $response = $this->jsonResponse(['id' => '42', 'body' => [], 'created' => '', 'updated' => '', 'self' => '', 'jsdPublic' => true, 'visibility' => []]);
+        $client = $this->mockClientExpecting('GET', 'issue/KEY-1/comment/42', ['query' => []], $response);
+        $api = new Comments($client);
+
+        $result = $api->show('KEY-1', '42');
+
+        $this->assertInstanceOf(Comment::class, $result, 'Comments::show() should return a Comment instance');
+        $this->assertSame('42', $result->getId(), 'Comments::show() should return the comment with the correct ID');
+    }
+
+    public function test_create(): void
+    {
+        $response = $this->jsonResponse(['id' => '100', 'body' => ['type' => 'doc'], 'created' => '', 'updated' => '', 'self' => '', 'jsdPublic' => true, 'visibility' => []]);
+        $client = $this->mockClientExpecting('POST', 'issue/KEY-1/comment', ['json' => ['body' => ['type' => 'doc']]], $response);
+        $api = new Comments($client);
+
+        $result = $api->create('KEY-1', ['body' => ['type' => 'doc']]);
+
+        $this->assertInstanceOf(Comment::class, $result, 'Comments::create() should return a Comment instance');
+        $this->assertSame('100', $result->getId(), 'Comments::create() should return the new comment with the correct ID');
+    }
+
+    public function test_update(): void
+    {
+        $response = $this->jsonResponse(['id' => '42', 'body' => ['type' => 'doc'], 'created' => '', 'updated' => '', 'self' => '', 'jsdPublic' => true, 'visibility' => []]);
+        $client = $this->mockClientExpecting('PUT', 'issue/KEY-1/comment/42', ['json' => ['body' => ['type' => 'doc']]], $response);
+        $api = new Comments($client);
+
+        $result = $api->update('KEY-1', '42', ['body' => ['type' => 'doc']]);
+
+        $this->assertInstanceOf(Comment::class, $result, 'Comments::update() should return a Comment instance');
+        $this->assertSame('42', $result->getId(), 'Comments::update() should return the updated comment with the correct ID');
+    }
+
+    public function test_delete(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('DELETE', 'issue/KEY-1/comment/42', ['query' => []], $response);
+        $api = new Comments($client);
+
+        $result = $api->delete('KEY-1', '42');
+
+        $this->assertSame([], $result, 'Comments::delete() should return an empty array for a successful 204 No Content response');
+    }
+}

--- a/tests/Api/FieldsTest.php
+++ b/tests/Api/FieldsTest.php
@@ -74,6 +74,20 @@ class FieldsTest extends TestCase
         $this->assertCount(1, $result->getFields(), 'Fields::index() should return exactly 1 field from the response');
     }
 
+    // ── getLabels ─────────────────────────────────────────────────────────
+
+    public function test_get_labels(): void
+    {
+        $labelsData = ['values' => ['backend', 'bug', 'frontend'], 'total' => 3];
+        $response = $this->jsonResponse($labelsData);
+        $client = $this->mockClientExpecting('GET', 'label', ['query' => []], $response);
+        $api = new Fields($client);
+
+        $result = $api->getLabels();
+
+        $this->assertSame($labelsData, $result, 'Fields::getLabels() should return the raw label data array from the API response');
+    }
+
     // ── getFieldOptions ───────────────────────────────────────────────────
 
     public function test_get_field_options_happy_path(): void

--- a/tests/Api/HttpApiTest.php
+++ b/tests/Api/HttpApiTest.php
@@ -50,9 +50,9 @@ class HttpApiTest extends TestCase
                 return $this->httpPut($path, $parameters);
             }
 
-            public function callHttpDelete(string $path): ResponseInterface
+            public function callHttpDelete(string $path, array $parameters = []): ResponseInterface
             {
-                return $this->httpDelete($path);
+                return $this->httpDelete($path, $parameters);
             }
 
             public function callHttpPostWithAttachments(string $path, array $multipart = []): ResponseInterface
@@ -212,10 +212,19 @@ class HttpApiTest extends TestCase
     public function test_http_delete_passes_path(): void
     {
         $response = $this->noContentResponse();
-        $client = $this->mockClientExpecting('DELETE', 'issue/KEY-1', [], $response);
+        $client = $this->mockClientExpecting('DELETE', 'issue/KEY-1', ['query' => []], $response);
         $api = $this->makeApi($client);
 
         $api->callHttpDelete('issue/KEY-1');
+    }
+
+    public function test_http_delete_passes_query_params(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('DELETE', 'issue/KEY-1/watchers', ['query' => ['accountId' => 'u1']], $response);
+        $api = $this->makeApi($client);
+
+        $api->callHttpDelete('issue/KEY-1/watchers', ['accountId' => 'u1']);
     }
 
     public function test_http_post_with_attachments_passes_multipart_and_headers(): void

--- a/tests/Api/HttpApiTest.php
+++ b/tests/Api/HttpApiTest.php
@@ -4,6 +4,8 @@ namespace CaptureHigherEd\LaravelJira\Tests\Api;
 
 use CaptureHigherEd\LaravelJira\Api\HttpApi;
 use CaptureHigherEd\LaravelJira\Exception\HttpClientException;
+use CaptureHigherEd\LaravelJira\Models\ApiResponse;
+use CaptureHigherEd\LaravelJira\Models\Paginated;
 use CaptureHigherEd\LaravelJira\Models\Search;
 use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
 use GuzzleHttp\ClientInterface;
@@ -58,6 +60,18 @@ class HttpApiTest extends TestCase
             public function callHttpPostWithAttachments(string $path, array $multipart = []): ResponseInterface
             {
                 return $this->httpPostWithAttachments($path, $multipart);
+            }
+
+            /**
+             * @template T of Paginated&ApiResponse
+             *
+             * @param  array<string, mixed>  $parameters
+             * @param  class-string<T>  $class
+             * @return \Generator<int, T, mixed, void>
+             */
+            public function callPaginateGet(string $path, array $parameters, string $class): \Generator
+            {
+                return $this->paginateGet($path, $parameters, $class);
             }
         };
     }
@@ -241,5 +255,60 @@ class HttpApiTest extends TestCase
         $api = $this->makeApi($client);
 
         $api->callHttpPostWithAttachments('issue/KEY-1/attachments', $multipart);
+    }
+
+    // ── paginateGet ───────────────────────────────────────────────────────
+
+    public function test_paginate_get_single_page(): void
+    {
+        $response = $this->jsonResponse(['issues' => [], 'total' => 3, 'maxResults' => 50, 'startAt' => 0]);
+        $client = $this->mockClientWithResponses([$response]);
+        $api = $this->makeApi($client);
+
+        $pages = iterator_to_array($api->callPaginateGet('search/jql', [], Search::class));
+
+        $this->assertCount(1, $pages, 'Single page should yield exactly 1 result');
+        $this->assertInstanceOf(Search::class, $pages[0], 'Yielded value should be a Search instance');
+        $this->assertSame(3, $pages[0]->getTotal(), 'Total should be hydrated from response');
+    }
+
+    public function test_paginate_get_multiple_pages(): void
+    {
+        $page1 = $this->jsonResponse(['issues' => [], 'total' => 3, 'maxResults' => 1, 'startAt' => 0]);
+        $page2 = $this->jsonResponse(['issues' => [], 'total' => 3, 'maxResults' => 1, 'startAt' => 1]);
+        $page3 = $this->jsonResponse(['issues' => [], 'total' => 3, 'maxResults' => 1, 'startAt' => 2]);
+        $client = $this->mockClientWithResponses([$page1, $page2, $page3]);
+        $api = $this->makeApi($client);
+
+        $pages = iterator_to_array($api->callPaginateGet('search/jql', [], Search::class));
+
+        $this->assertCount(3, $pages, 'Three pages should yield exactly 3 results');
+        $this->assertSame(0, $pages[0]->getStartAt(), 'First page startAt should be 0');
+        $this->assertSame(1, $pages[1]->getStartAt(), 'Second page startAt should be 1');
+        $this->assertSame(2, $pages[2]->getStartAt(), 'Third page startAt should be 2');
+    }
+
+    public function test_paginate_get_empty_results(): void
+    {
+        $response = $this->jsonResponse(['issues' => [], 'total' => 0, 'maxResults' => 50, 'startAt' => 0]);
+        $client = $this->mockClientWithResponses([$response]);
+        $api = $this->makeApi($client);
+
+        $pages = iterator_to_array($api->callPaginateGet('search/jql', [], Search::class));
+
+        $this->assertCount(1, $pages, 'Empty results should still yield 1 (empty) page');
+        $this->assertSame(0, $pages[0]->getTotal(), 'Total should be 0 for empty results');
+    }
+
+    public function test_paginate_get_respects_initial_start_at(): void
+    {
+        $response = $this->jsonResponse(['issues' => [], 'total' => 10, 'maxResults' => 10, 'startAt' => 5]);
+        $client = $this->mockClientWithResponses([$response]);
+        $api = $this->makeApi($client);
+
+        $pages = iterator_to_array($api->callPaginateGet('search/jql', ['startAt' => 5], Search::class));
+
+        $this->assertCount(1, $pages, 'Should yield 1 page when startAt + maxResults >= total');
+        $this->assertSame(5, $pages[0]->getStartAt(), 'startAt should reflect initial offset');
     }
 }

--- a/tests/Api/IssueLinksTest.php
+++ b/tests/Api/IssueLinksTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Api;
+
+use CaptureHigherEd\LaravelJira\Api\IssueLinks;
+use CaptureHigherEd\LaravelJira\Models\IssueLink;
+use CaptureHigherEd\LaravelJira\Models\IssueLinkTypes;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use PHPUnit\Framework\TestCase;
+
+class IssueLinksTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    public function test_create(): void
+    {
+        $response = $this->mockResponse(201, null);
+        $params = ['type' => ['name' => 'Blocks'], 'inwardIssue' => ['key' => 'KEY-1'], 'outwardIssue' => ['key' => 'KEY-2']];
+        $client = $this->mockClientExpecting('POST', 'issueLink', ['json' => $params], $response);
+        $api = new IssueLinks($client);
+
+        $result = $api->create($params);
+
+        $this->assertSame([], $result, 'IssueLinks::create() should return an empty array for a 201 response with no body');
+    }
+
+    public function test_show(): void
+    {
+        $response = $this->jsonResponse([
+            'id' => '10000',
+            'self' => 'https://example.atlassian.net/rest/api/3/issueLink/10000',
+            'type' => ['id' => '1', 'name' => 'Blocks', 'inward' => 'is blocked by', 'outward' => 'blocks'],
+            'inwardIssue' => ['id' => '10001', 'key' => 'KEY-1'],
+            'outwardIssue' => ['id' => '10002', 'key' => 'KEY-2'],
+        ]);
+        $client = $this->mockClientExpecting('GET', 'issueLink/10000', ['query' => []], $response);
+        $api = new IssueLinks($client);
+
+        $result = $api->show('10000');
+
+        $this->assertInstanceOf(IssueLink::class, $result, 'IssueLinks::show() should return an IssueLink instance');
+        $this->assertSame('10000', $result->getId(), 'IssueLinks::show() should return the link with the correct ID');
+    }
+
+    public function test_delete(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('DELETE', 'issueLink/10000', ['query' => []], $response);
+        $api = new IssueLinks($client);
+
+        $result = $api->delete('10000');
+
+        $this->assertSame([], $result, 'IssueLinks::delete() should return an empty array for a successful 204 No Content response');
+    }
+
+    public function test_get_types(): void
+    {
+        $response = $this->jsonResponse([
+            'issueLinkTypes' => [
+                ['id' => '1', 'name' => 'Blocks', 'inward' => 'is blocked by', 'outward' => 'blocks', 'self' => ''],
+            ],
+        ]);
+        $client = $this->mockClientExpecting('GET', 'issueLinkType', ['query' => []], $response);
+        $api = new IssueLinks($client);
+
+        $result = $api->getTypes();
+
+        $this->assertInstanceOf(IssueLinkTypes::class, $result, 'IssueLinks::getTypes() should return an IssueLinkTypes instance');
+        $this->assertCount(1, $result->getTypes(), 'IssueLinks::getTypes() should return the correct number of link types');
+        $this->assertSame('Blocks', $result->getTypes()[0]->getName(), 'IssueLinks::getTypes() should hydrate the type name correctly');
+    }
+}

--- a/tests/Api/IssuesTest.php
+++ b/tests/Api/IssuesTest.php
@@ -244,4 +244,44 @@ class IssuesTest extends TestCase
 
         $this->assertSame([], $result, 'Issues::removeWatcher() should return an empty array for a successful 204 No Content response');
     }
+
+    // ── pagination ────────────────────────────────────────────────────────
+
+    public function test_paginate(): void
+    {
+        $page1 = $this->jsonResponse(['issues' => [], 'total' => 2, 'maxResults' => 1, 'startAt' => 0]);
+        $page2 = $this->jsonResponse(['issues' => [], 'total' => 2, 'maxResults' => 1, 'startAt' => 1]);
+        $client = $this->mockClientWithResponses([$page1, $page2]);
+        $api = new Issues($client);
+
+        $pages = iterator_to_array($api->paginate());
+
+        $this->assertCount(2, $pages, 'Issues::paginate() should yield one Search per page');
+        $this->assertInstanceOf(Search::class, $pages[0], 'Each yielded value should be a Search instance');
+        $this->assertSame(2, $pages[0]->getTotal(), 'Total should be hydrated from the first page');
+    }
+
+    public function test_paginate_create_meta_issue_types(): void
+    {
+        $response = $this->jsonResponse(['issueTypes' => [], 'total' => 0, 'maxResults' => 50, 'startAt' => 0]);
+        $client = $this->mockClientWithResponses([$response]);
+        $api = new Issues($client);
+
+        $pages = iterator_to_array($api->paginateCreateMetaIssueTypes('TEST'));
+
+        $this->assertCount(1, $pages, 'paginateCreateMetaIssueTypes() should yield one page');
+        $this->assertInstanceOf(IssueTypes::class, $pages[0], 'Each yielded value should be an IssueTypes instance');
+    }
+
+    public function test_paginate_create_meta_fields(): void
+    {
+        $response = $this->jsonResponse(['fields' => [], 'total' => 0, 'maxResults' => 50, 'startAt' => 0]);
+        $client = $this->mockClientWithResponses([$response]);
+        $api = new Issues($client);
+
+        $pages = iterator_to_array($api->paginateCreateMetaFields('TEST', '10001'));
+
+        $this->assertCount(1, $pages, 'paginateCreateMetaFields() should yield one page');
+        $this->assertInstanceOf(FieldMetas::class, $pages[0], 'Each yielded value should be a FieldMetas instance');
+    }
 }

--- a/tests/Api/IssuesTest.php
+++ b/tests/Api/IssuesTest.php
@@ -9,6 +9,8 @@ use CaptureHigherEd\LaravelJira\Models\FieldMetas;
 use CaptureHigherEd\LaravelJira\Models\Issue;
 use CaptureHigherEd\LaravelJira\Models\IssueTypes;
 use CaptureHigherEd\LaravelJira\Models\Search;
+use CaptureHigherEd\LaravelJira\Models\Transitions;
+use CaptureHigherEd\LaravelJira\Models\Watchers;
 use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
 use PHPUnit\Framework\TestCase;
 
@@ -148,11 +150,98 @@ class IssuesTest extends TestCase
     public function test_delete(): void
     {
         $response = $this->noContentResponse();
-        $client = $this->mockClientExpecting('DELETE', 'issue/KEY-1', [], $response);
+        $client = $this->mockClientExpecting('DELETE', 'issue/KEY-1', ['query' => []], $response);
         $api = new Issues($client);
 
         $result = $api->delete('KEY-1');
 
         $this->assertSame([], $result, 'Issues::delete() should return an empty array for a successful 204 No Content response');
+    }
+
+    // ── Transitions & assignment ───────────────────────────────────────────
+
+    public function test_get_transitions(): void
+    {
+        $response = $this->jsonResponse([
+            'transitions' => [
+                ['id' => '1', 'name' => 'To Do', 'hasScreen' => false, 'isGlobal' => false, 'isInitial' => true, 'isConditional' => false],
+                ['id' => '2', 'name' => 'In Progress', 'hasScreen' => false, 'isGlobal' => true, 'isInitial' => false, 'isConditional' => false],
+            ],
+        ]);
+        $client = $this->mockClientExpecting('GET', 'issue/KEY-1/transitions', ['query' => []], $response);
+        $api = new Issues($client);
+
+        $result = $api->getTransitions('KEY-1');
+
+        $this->assertInstanceOf(Transitions::class, $result, 'Issues::getTransitions() should return a Transitions instance');
+        $this->assertCount(2, $result->getTransitions(), 'Issues::getTransitions() should return the correct number of transitions');
+        $this->assertSame('1', $result->getTransitions()[0]->getId(), 'Issues::getTransitions() should hydrate the transition ID correctly');
+    }
+
+    public function test_transition(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('POST', 'issue/KEY-1/transitions', ['json' => ['transition' => ['id' => '5']]], $response);
+        $api = new Issues($client);
+
+        $result = $api->transition('KEY-1', ['transition' => ['id' => '5']]);
+
+        $this->assertSame([], $result, 'Issues::transition() should return an empty array for a successful 204 No Content response');
+    }
+
+    public function test_assign(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('PUT', 'issue/KEY-1/assignee', ['json' => ['accountId' => 'u1']], $response);
+        $api = new Issues($client);
+
+        $result = $api->assign('KEY-1', 'u1');
+
+        $this->assertSame([], $result, 'Issues::assign() should return an empty array for a successful 204 No Content response');
+    }
+
+    // ── Watchers ──────────────────────────────────────────────────────────
+
+    public function test_get_watchers(): void
+    {
+        $response = $this->jsonResponse([
+            'self' => 'https://example.atlassian.net/rest/api/3/issue/KEY-1/watchers',
+            'isWatching' => true,
+            'watchCount' => 1,
+            'watchers' => [['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => '', 'active' => true]],
+        ]);
+        $client = $this->mockClientExpecting('GET', 'issue/KEY-1/watchers', ['query' => []], $response);
+        $api = new Issues($client);
+
+        $result = $api->getWatchers('KEY-1');
+
+        $this->assertInstanceOf(Watchers::class, $result, 'Issues::getWatchers() should return a Watchers instance');
+        $this->assertSame(1, $result->getWatchCount(), 'Issues::getWatchers() should hydrate the watch count correctly');
+        $this->assertCount(1, $result->getWatchers(), 'Issues::getWatchers() should hydrate the watchers list correctly');
+    }
+
+    public function test_add_watcher(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('POST', 'issue/KEY-1/watchers', [
+            'body' => '"u1"',
+            'headers' => ['Content-Type' => 'application/json'],
+        ], $response);
+        $api = new Issues($client);
+
+        $result = $api->addWatcher('KEY-1', 'u1');
+
+        $this->assertSame([], $result, 'Issues::addWatcher() should return an empty array for a successful 204 No Content response');
+    }
+
+    public function test_remove_watcher(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('DELETE', 'issue/KEY-1/watchers', ['query' => ['accountId' => 'u1']], $response);
+        $api = new Issues($client);
+
+        $result = $api->removeWatcher('KEY-1', 'u1');
+
+        $this->assertSame([], $result, 'Issues::removeWatcher() should return an empty array for a successful 204 No Content response');
     }
 }

--- a/tests/Api/ProjectsTest.php
+++ b/tests/Api/ProjectsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Api;
+
+use CaptureHigherEd\LaravelJira\Api\Projects;
+use CaptureHigherEd\LaravelJira\Models\Project;
+use CaptureHigherEd\LaravelJira\Models\Projects as ModelsProjects;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use PHPUnit\Framework\TestCase;
+
+class ProjectsTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    public function test_index(): void
+    {
+        $response = $this->jsonResponse([
+            ['id' => '10000', 'key' => 'TEST', 'name' => 'Test Project', 'self' => '', 'projectTypeKey' => 'software', 'simplified' => false, 'avatarUrls' => []],
+        ]);
+        $client = $this->mockClientExpecting('GET', 'project', ['query' => []], $response);
+        $api = new Projects($client);
+
+        $result = $api->index();
+
+        $this->assertInstanceOf(ModelsProjects::class, $result, 'Projects::index() should return a Projects model instance');
+        $this->assertCount(1, $result->getProjects(), 'Projects::index() should return exactly 1 project from the response');
+        $this->assertSame('TEST', $result->getProjects()[0]->getKey(), 'Projects::index() should hydrate the project key correctly');
+    }
+
+    public function test_index_with_params(): void
+    {
+        $response = $this->jsonResponse([]);
+        $client = $this->mockClientExpecting('GET', 'project', ['query' => ['maxResults' => 10]], $response);
+        $api = new Projects($client);
+
+        $result = $api->index(['maxResults' => 10]);
+
+        $this->assertInstanceOf(ModelsProjects::class, $result, 'Projects::index() should return a Projects model when called with params');
+    }
+
+    public function test_show(): void
+    {
+        $response = $this->jsonResponse(['id' => '10000', 'key' => 'TEST', 'name' => 'Test Project', 'self' => '', 'projectTypeKey' => 'software', 'simplified' => false, 'avatarUrls' => []]);
+        $client = $this->mockClientExpecting('GET', 'project/TEST', ['query' => []], $response);
+        $api = new Projects($client);
+
+        $result = $api->show('TEST');
+
+        $this->assertInstanceOf(Project::class, $result, 'Projects::show() should return a Project model instance');
+        $this->assertSame('TEST', $result->getKey(), 'Projects::show() should return the project with the correct key');
+    }
+}

--- a/tests/Api/UsersTest.php
+++ b/tests/Api/UsersTest.php
@@ -3,6 +3,7 @@
 namespace CaptureHigherEd\LaravelJira\Tests\Api;
 
 use CaptureHigherEd\LaravelJira\Api\Users;
+use CaptureHigherEd\LaravelJira\Models\User;
 use CaptureHigherEd\LaravelJira\Models\Users as ModelsUsers;
 use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
 use PHPUnit\Framework\TestCase;
@@ -34,5 +35,43 @@ class UsersTest extends TestCase
         $result = $api->index(['maxResults' => 50, 'startAt' => 100]);
 
         $this->assertInstanceOf(ModelsUsers::class, $result, 'Users::index() should return a Users model instance when called with custom query parameters');
+    }
+
+    public function test_show(): void
+    {
+        $response = $this->jsonResponse(['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => 'alice@example.com', 'active' => true]);
+        $client = $this->mockClientExpecting('GET', 'user', ['query' => ['accountId' => 'u1']], $response);
+        $api = new Users($client);
+
+        $result = $api->show('u1');
+
+        $this->assertInstanceOf(User::class, $result, 'Users::show() should return a User model instance');
+        $this->assertSame('u1', $result->getKey(), 'Users::show() should return the user with the correct accountId');
+    }
+
+    public function test_search(): void
+    {
+        $response = $this->jsonResponse([
+            ['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => 'alice@example.com', 'active' => true],
+        ]);
+        $client = $this->mockClientExpecting('GET', 'user/search', ['query' => ['query' => 'alice']], $response);
+        $api = new Users($client);
+
+        $result = $api->search(['query' => 'alice']);
+
+        $this->assertInstanceOf(ModelsUsers::class, $result, 'Users::search() should return a Users model instance');
+        $this->assertCount(1, $result->getUsers(), 'Users::search() should return exactly 1 user from the response');
+    }
+
+    public function test_myself(): void
+    {
+        $response = $this->jsonResponse(['accountId' => 'me', 'displayName' => 'Current User', 'emailAddress' => 'me@example.com', 'active' => true]);
+        $client = $this->mockClientExpecting('GET', 'myself', ['query' => []], $response);
+        $api = new Users($client);
+
+        $result = $api->myself();
+
+        $this->assertInstanceOf(User::class, $result, 'Users::myself() should return a User model instance');
+        $this->assertSame('me', $result->getKey(), 'Users::myself() should return the current user with the correct accountId');
     }
 }

--- a/tests/Api/WorklogsTest.php
+++ b/tests/Api/WorklogsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Api;
+
+use CaptureHigherEd\LaravelJira\Api\Worklogs;
+use CaptureHigherEd\LaravelJira\Models\Worklog;
+use CaptureHigherEd\LaravelJira\Models\Worklogs as ModelsWorklogs;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use PHPUnit\Framework\TestCase;
+
+class WorklogsTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    public function test_index(): void
+    {
+        $response = $this->jsonResponse([
+            'worklogs' => [
+                ['id' => '1', 'self' => '', 'comment' => [], 'started' => '2024-01-01T09:00:00.000+0000', 'timeSpent' => '1h', 'timeSpentSeconds' => 3600, 'issueId' => '10001', 'created' => '', 'updated' => ''],
+            ],
+            'total' => 1,
+            'maxResults' => 20,
+            'startAt' => 0,
+        ]);
+        $client = $this->mockClientExpecting('GET', 'issue/KEY-1/worklog', ['query' => []], $response);
+        $api = new Worklogs($client);
+
+        $result = $api->index('KEY-1');
+
+        $this->assertInstanceOf(ModelsWorklogs::class, $result, 'Worklogs::index() should return a ModelsWorklogs instance');
+        $this->assertCount(1, $result->getWorklogs(), 'Worklogs::index() should return exactly 1 worklog from the response');
+        $this->assertSame(1, $result->getTotal(), 'Worklogs::index() should hydrate the total count correctly');
+    }
+
+    public function test_create(): void
+    {
+        $worklogData = ['id' => '200', 'self' => '', 'comment' => [], 'started' => '2024-01-01T09:00:00.000+0000', 'timeSpent' => '2h', 'timeSpentSeconds' => 7200, 'issueId' => '10001', 'created' => '', 'updated' => ''];
+        $response = $this->mockResponse(201, $worklogData);
+        $client = $this->mockClientExpecting('POST', 'issue/KEY-1/worklog', ['json' => ['timeSpent' => '2h', 'started' => '2024-01-01T09:00:00.000+0000']], $response);
+        $api = new Worklogs($client);
+
+        $result = $api->create('KEY-1', ['timeSpent' => '2h', 'started' => '2024-01-01T09:00:00.000+0000']);
+
+        $this->assertInstanceOf(Worklog::class, $result, 'Worklogs::create() should return a Worklog instance');
+        $this->assertSame('200', $result->getId(), 'Worklogs::create() should return the new worklog with the correct ID');
+    }
+
+    public function test_update(): void
+    {
+        $worklogData = ['id' => '200', 'self' => '', 'comment' => [], 'started' => '', 'timeSpent' => '3h', 'timeSpentSeconds' => 10800, 'issueId' => '10001', 'created' => '', 'updated' => ''];
+        $response = $this->jsonResponse($worklogData);
+        $client = $this->mockClientExpecting('PUT', 'issue/KEY-1/worklog/200', ['json' => ['timeSpent' => '3h']], $response);
+        $api = new Worklogs($client);
+
+        $result = $api->update('KEY-1', '200', ['timeSpent' => '3h']);
+
+        $this->assertInstanceOf(Worklog::class, $result, 'Worklogs::update() should return a Worklog instance');
+        $this->assertSame('3h', $result->getTimeSpent(), 'Worklogs::update() should return the updated worklog with the correct timeSpent');
+    }
+
+    public function test_delete(): void
+    {
+        $response = $this->noContentResponse();
+        $client = $this->mockClientExpecting('DELETE', 'issue/KEY-1/worklog/200', ['query' => []], $response);
+        $api = new Worklogs($client);
+
+        $result = $api->delete('KEY-1', '200');
+
+        $this->assertSame([], $result, 'Worklogs::delete() should return an empty array for a successful 204 No Content response');
+    }
+}

--- a/tests/Api/WorklogsTest.php
+++ b/tests/Api/WorklogsTest.php
@@ -68,4 +68,18 @@ class WorklogsTest extends TestCase
 
         $this->assertSame([], $result, 'Worklogs::delete() should return an empty array for a successful 204 No Content response');
     }
+
+    public function test_paginate(): void
+    {
+        $page1 = $this->jsonResponse(['worklogs' => [], 'total' => 2, 'maxResults' => 1, 'startAt' => 0]);
+        $page2 = $this->jsonResponse(['worklogs' => [], 'total' => 2, 'maxResults' => 1, 'startAt' => 1]);
+        $client = $this->mockClientWithResponses([$page1, $page2]);
+        $api = new Worklogs($client);
+
+        $pages = iterator_to_array($api->paginate('KEY-1'));
+
+        $this->assertCount(2, $pages, 'Worklogs::paginate() should yield one page per HTTP response');
+        $this->assertInstanceOf(ModelsWorklogs::class, $pages[0], 'Each yielded value should be a ModelsWorklogs instance');
+        $this->assertSame(2, $pages[0]->getTotal(), 'Total should be hydrated from the first page response');
+    }
 }

--- a/tests/Concerns/MocksHttpResponses.php
+++ b/tests/Concerns/MocksHttpResponses.php
@@ -62,4 +62,15 @@ trait MocksHttpResponses
 
         return $client;
     }
+
+    /**
+     * @param  array<int, ResponseInterface>  $responses
+     */
+    protected function mockClientWithResponses(array $responses): ClientInterface
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('request')->willReturnOnConsecutiveCalls(...$responses);
+
+        return $client;
+    }
 }

--- a/tests/Models/CommentsTest.php
+++ b/tests/Models/CommentsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Comment;
+use CaptureHigherEd\LaravelJira\Models\Comments;
+use PHPUnit\Framework\TestCase;
+
+class CommentsTest extends TestCase
+{
+    public function test_make_with_empty_data(): void
+    {
+        $collection = Comments::make();
+
+        $this->assertSame([], $collection->getComments(), 'Comments should default to an empty comments array when not provided');
+        $this->assertSame(0, $collection->getTotal(), 'Comments total should default to 0 when not provided');
+        $this->assertSame(0, $collection->getMaxResults(), 'Comments maxResults should default to 0 when not provided');
+        $this->assertSame(0, $collection->getStartAt(), 'Comments startAt should default to 0 when not provided');
+    }
+
+    public function test_make_hydrates_comments_and_pagination(): void
+    {
+        $data = [
+            'comments' => [
+                ['id' => '1', 'body' => [], 'created' => '', 'updated' => '', 'self' => '', 'jsdPublic' => true, 'visibility' => []],
+                ['id' => '2', 'body' => [], 'created' => '', 'updated' => '', 'self' => '', 'jsdPublic' => true, 'visibility' => []],
+            ],
+            'total' => 10,
+            'maxResults' => 50,
+            'startAt' => 0,
+        ];
+
+        $collection = Comments::make($data);
+
+        $this->assertCount(2, $collection->getComments(), 'Comments should hydrate the correct number of comments');
+        $this->assertInstanceOf(Comment::class, $collection->getComments()[0], 'Each comment should be hydrated as a Comment instance');
+        $this->assertSame(10, $collection->getTotal(), 'Comments total should be hydrated correctly');
+        $this->assertSame(50, $collection->getMaxResults(), 'Comments maxResults should be hydrated correctly');
+        $this->assertSame(0, $collection->getStartAt(), 'Comments startAt should be hydrated correctly');
+    }
+
+    public function test_to_array_roundtrip(): void
+    {
+        $data = [
+            'comments' => [
+                ['id' => '1', 'body' => [], 'created' => '', 'updated' => '', 'self' => '', 'author' => null, 'updateAuthor' => null, 'jsdPublic' => true, 'visibility' => []],
+            ],
+            'total' => 1,
+            'maxResults' => 50,
+            'startAt' => 0,
+        ];
+
+        $collection = Comments::make($data);
+
+        $this->assertSame($data, $collection->toArray(), 'Comments::toArray() should return the same data passed to make()');
+    }
+}

--- a/tests/Models/Concerns/HasPaginationTest.php
+++ b/tests/Models/Concerns/HasPaginationTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models\Concerns;
+
+use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;
+use CaptureHigherEd\LaravelJira\Models\Paginated;
+use PHPUnit\Framework\TestCase;
+
+class HasPaginationTest extends TestCase
+{
+    private function makeModel(): Paginated
+    {
+        return new class implements Paginated
+        {
+            use HasPagination;
+        };
+    }
+
+    public function test_defaults_to_zero(): void
+    {
+        $model = $this->makeModel();
+
+        $this->assertSame(0, $model->getTotal(), 'total should default to 0');
+        $this->assertSame(0, $model->getMaxResults(), 'maxResults should default to 0');
+        $this->assertSame(0, $model->getStartAt(), 'startAt should default to 0');
+    }
+
+    public function test_setters_return_static(): void
+    {
+        $model = $this->makeModel();
+
+        $this->assertSame($model, $model->setTotal(10), 'setTotal() should return static');
+        $this->assertSame($model, $model->setMaxResults(50), 'setMaxResults() should return static');
+        $this->assertSame($model, $model->setStartAt(0), 'setStartAt() should return static');
+    }
+
+    public function test_setters_update_values(): void
+    {
+        $model = $this->makeModel();
+        $model->setTotal(100)->setMaxResults(25)->setStartAt(50);
+
+        $this->assertSame(100, $model->getTotal(), 'setTotal() should update total');
+        $this->assertSame(25, $model->getMaxResults(), 'setMaxResults() should update maxResults');
+        $this->assertSame(50, $model->getStartAt(), 'setStartAt() should update startAt');
+    }
+
+    public function test_has_more_returns_true_when_more_pages(): void
+    {
+        $model = $this->makeModel();
+        $model->setTotal(100)->setMaxResults(25)->setStartAt(0);
+
+        $this->assertTrue($model->hasMore(), 'hasMore() should return true when startAt + maxResults < total');
+    }
+
+    public function test_has_more_returns_false_on_last_page(): void
+    {
+        $model = $this->makeModel();
+        $model->setTotal(100)->setMaxResults(25)->setStartAt(75);
+
+        $this->assertFalse($model->hasMore(), 'hasMore() should return false when startAt + maxResults >= total');
+    }
+
+    public function test_has_more_returns_false_when_total_is_zero(): void
+    {
+        $model = $this->makeModel();
+        $model->setTotal(0)->setMaxResults(50)->setStartAt(0);
+
+        $this->assertFalse($model->hasMore(), 'hasMore() should return false when total is 0');
+    }
+
+    public function test_get_next_start_at(): void
+    {
+        $model = $this->makeModel();
+        $model->setStartAt(25)->setMaxResults(25);
+
+        $this->assertSame(50, $model->getNextStartAt(), 'getNextStartAt() should return startAt + maxResults');
+    }
+
+    public function test_hydrate_pagination(): void
+    {
+        $model = new class implements Paginated
+        {
+            use HasPagination;
+
+            public function callHydratePagination(array $data): void
+            {
+                $this->hydratePagination($data);
+            }
+        };
+
+        $model->callHydratePagination(['total' => 42, 'maxResults' => 10, 'startAt' => 20]);
+
+        $this->assertSame(42, $model->getTotal(), 'hydratePagination() should set total');
+        $this->assertSame(10, $model->getMaxResults(), 'hydratePagination() should set maxResults');
+        $this->assertSame(20, $model->getStartAt(), 'hydratePagination() should set startAt');
+    }
+
+    public function test_pagination_to_array(): void
+    {
+        $model = new class implements Paginated
+        {
+            use HasPagination;
+
+            /** @return array<string, int> */
+            public function callPaginationToArray(): array
+            {
+                return $this->paginationToArray();
+            }
+        };
+
+        $model->setTotal(99)->setMaxResults(20)->setStartAt(40);
+
+        $this->assertSame(
+            ['total' => 99, 'maxResults' => 20, 'startAt' => 40],
+            $model->callPaginationToArray(),
+            'paginationToArray() should return the correct pagination keys'
+        );
+    }
+}

--- a/tests/Models/FieldMetasTest.php
+++ b/tests/Models/FieldMetasTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\FieldMeta;
+use CaptureHigherEd\LaravelJira\Models\FieldMetas;
+use CaptureHigherEd\LaravelJira\Models\Paginated;
+use PHPUnit\Framework\TestCase;
+
+class FieldMetasTest extends TestCase
+{
+    private function fieldMetaData(): array
+    {
+        return [
+            'fieldId' => 'summary',
+            'name' => 'Summary',
+            'required' => true,
+            'schema' => ['type' => 'string'],
+            'operations' => ['set'],
+            'allowedValues' => [],
+        ];
+    }
+
+    public function test_implements_paginated(): void
+    {
+        $this->assertInstanceOf(Paginated::class, FieldMetas::make(), 'FieldMetas should implement the Paginated interface');
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $collection = FieldMetas::make();
+
+        $this->assertSame([], $collection->getFields(), 'FieldMetas should default to an empty array');
+        $this->assertSame(0, $collection->getTotal(), 'FieldMetas total should default to 0');
+        $this->assertSame(0, $collection->getMaxResults(), 'FieldMetas maxResults should default to 0');
+        $this->assertSame(0, $collection->getStartAt(), 'FieldMetas startAt should default to 0');
+    }
+
+    public function test_make_hydrates_fields_and_pagination(): void
+    {
+        $data = [
+            'fields' => [$this->fieldMetaData()],
+            'total' => 3,
+            'maxResults' => 50,
+            'startAt' => 0,
+        ];
+
+        $collection = FieldMetas::make($data);
+
+        $this->assertCount(1, $collection->getFields(), 'FieldMetas should hydrate the correct number of fields');
+        $this->assertInstanceOf(FieldMeta::class, $collection->getFields()[0], 'Each item should be hydrated as a FieldMeta instance');
+        $this->assertSame(3, $collection->getTotal(), 'FieldMetas total should be hydrated correctly');
+        $this->assertSame(50, $collection->getMaxResults(), 'FieldMetas maxResults should be hydrated correctly');
+        $this->assertSame(0, $collection->getStartAt(), 'FieldMetas startAt should be hydrated correctly');
+    }
+
+    public function test_to_array_roundtrip(): void
+    {
+        $data = [
+            'fields' => [$this->fieldMetaData()],
+            'total' => 1,
+            'maxResults' => 50,
+            'startAt' => 0,
+        ];
+
+        $collection = FieldMetas::make($data);
+
+        $this->assertSame($data, $collection->toArray(), 'FieldMetas::toArray() should return the same data passed to make()');
+    }
+
+    public function test_has_more(): void
+    {
+        $collection = FieldMetas::make(['fields' => [], 'total' => 20, 'maxResults' => 10, 'startAt' => 0]);
+
+        $this->assertTrue($collection->hasMore(), 'hasMore() should return true when more pages exist');
+    }
+}

--- a/tests/Models/IssueLinkTest.php
+++ b/tests/Models/IssueLinkTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\IssueLink;
+use PHPUnit\Framework\TestCase;
+
+class IssueLinkTest extends TestCase
+{
+    public function test_make_with_empty_data(): void
+    {
+        $link = IssueLink::make();
+
+        $this->assertSame('', $link->getId(), 'IssueLink ID should default to an empty string when not provided');
+        $this->assertSame('', $link->getSelf(), 'IssueLink self URL should default to an empty string when not provided');
+        $this->assertSame([], $link->getType(), 'IssueLink type should default to an empty array when not provided');
+        $this->assertSame([], $link->getInwardIssue(), 'IssueLink inwardIssue should default to an empty array when not provided');
+        $this->assertSame([], $link->getOutwardIssue(), 'IssueLink outwardIssue should default to an empty array when not provided');
+    }
+
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => '10000',
+            'self' => 'https://example.atlassian.net/rest/api/3/issueLink/10000',
+            'type' => ['id' => '1', 'name' => 'Blocks', 'inward' => 'is blocked by', 'outward' => 'blocks'],
+            'inwardIssue' => ['id' => '10001', 'key' => 'KEY-1'],
+            'outwardIssue' => ['id' => '10002', 'key' => 'KEY-2'],
+        ];
+
+        $link = IssueLink::make($data);
+
+        $this->assertSame($data, $link->toArray(), 'IssueLink::toArray() should return the same data passed to make()');
+    }
+}

--- a/tests/Models/IssueLinkTypeTest.php
+++ b/tests/Models/IssueLinkTypeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\IssueLinkType;
+use PHPUnit\Framework\TestCase;
+
+class IssueLinkTypeTest extends TestCase
+{
+    public function test_make_with_empty_data(): void
+    {
+        $type = IssueLinkType::make();
+
+        $this->assertSame('', $type->getId(), 'IssueLinkType ID should default to an empty string when not provided');
+        $this->assertSame('', $type->getName(), 'IssueLinkType name should default to an empty string when not provided');
+        $this->assertSame('', $type->getInward(), 'IssueLinkType inward should default to an empty string when not provided');
+        $this->assertSame('', $type->getOutward(), 'IssueLinkType outward should default to an empty string when not provided');
+        $this->assertSame('', $type->getSelf(), 'IssueLinkType self URL should default to an empty string when not provided');
+    }
+
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => '10001',
+            'name' => 'Blocks',
+            'inward' => 'is blocked by',
+            'outward' => 'blocks',
+            'self' => 'https://example.atlassian.net/rest/api/3/issueLinkType/10001',
+        ];
+
+        $type = IssueLinkType::make($data);
+
+        $this->assertSame($data, $type->toArray(), 'IssueLinkType::toArray() should return the same data passed to make()');
+    }
+}

--- a/tests/Models/IssueLinkTypesTest.php
+++ b/tests/Models/IssueLinkTypesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\IssueLinkType;
+use CaptureHigherEd\LaravelJira\Models\IssueLinkTypes;
+use PHPUnit\Framework\TestCase;
+
+class IssueLinkTypesTest extends TestCase
+{
+    public function test_make_with_empty_data(): void
+    {
+        $types = IssueLinkTypes::make();
+
+        $this->assertSame([], $types->getTypes(), 'IssueLinkTypes should default to an empty array when not provided');
+    }
+
+    public function test_make_hydrates_types(): void
+    {
+        $data = [
+            'issueLinkTypes' => [
+                ['id' => '1', 'name' => 'Blocks', 'inward' => 'is blocked by', 'outward' => 'blocks', 'self' => ''],
+                ['id' => '2', 'name' => 'Cloners', 'inward' => 'is cloned by', 'outward' => 'clones', 'self' => ''],
+            ],
+        ];
+
+        $types = IssueLinkTypes::make($data);
+
+        $this->assertCount(2, $types->getTypes(), 'IssueLinkTypes should hydrate the correct number of types');
+        $this->assertInstanceOf(IssueLinkType::class, $types->getTypes()[0], 'Each type should be hydrated as an IssueLinkType instance');
+        $this->assertSame('Blocks', $types->getTypes()[0]->getName(), 'First type name should be hydrated correctly');
+    }
+
+    public function test_to_array(): void
+    {
+        $data = [
+            'issueLinkTypes' => [
+                ['id' => '1', 'name' => 'Blocks', 'inward' => 'is blocked by', 'outward' => 'blocks', 'self' => ''],
+            ],
+        ];
+
+        $types = IssueLinkTypes::make($data);
+
+        $this->assertCount(1, $types->toArray(), 'IssueLinkTypes::toArray() should return a flat list of type arrays');
+        $this->assertSame('1', $types->toArray()[0]['id'], 'IssueLinkTypes::toArray() should preserve the type ID');
+    }
+}

--- a/tests/Models/IssueTypesTest.php
+++ b/tests/Models/IssueTypesTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\IssueType;
+use CaptureHigherEd\LaravelJira\Models\IssueTypes;
+use CaptureHigherEd\LaravelJira\Models\Paginated;
+use PHPUnit\Framework\TestCase;
+
+class IssueTypesTest extends TestCase
+{
+    private function issueTypeData(): array
+    {
+        return [
+            'id' => '10001',
+            'name' => 'Bug',
+            'description' => 'A bug',
+            'subtask' => false,
+            'iconUrl' => '',
+            'self' => '',
+        ];
+    }
+
+    public function test_implements_paginated(): void
+    {
+        $this->assertInstanceOf(Paginated::class, IssueTypes::make(), 'IssueTypes should implement the Paginated interface');
+    }
+
+    public function test_make_with_empty_data(): void
+    {
+        $collection = IssueTypes::make();
+
+        $this->assertSame([], $collection->getIssueTypes(), 'IssueTypes should default to an empty array');
+        $this->assertSame(0, $collection->getTotal(), 'IssueTypes total should default to 0');
+        $this->assertSame(0, $collection->getMaxResults(), 'IssueTypes maxResults should default to 0');
+        $this->assertSame(0, $collection->getStartAt(), 'IssueTypes startAt should default to 0');
+    }
+
+    public function test_make_hydrates_issue_types_and_pagination(): void
+    {
+        $data = [
+            'issueTypes' => [$this->issueTypeData()],
+            'total' => 5,
+            'maxResults' => 50,
+            'startAt' => 0,
+        ];
+
+        $collection = IssueTypes::make($data);
+
+        $this->assertCount(1, $collection->getIssueTypes(), 'IssueTypes should hydrate the correct number of issue types');
+        $this->assertInstanceOf(IssueType::class, $collection->getIssueTypes()[0], 'Each item should be hydrated as an IssueType instance');
+        $this->assertSame(5, $collection->getTotal(), 'IssueTypes total should be hydrated correctly');
+        $this->assertSame(50, $collection->getMaxResults(), 'IssueTypes maxResults should be hydrated correctly');
+        $this->assertSame(0, $collection->getStartAt(), 'IssueTypes startAt should be hydrated correctly');
+    }
+
+    public function test_to_array_roundtrip(): void
+    {
+        $data = [
+            'issueTypes' => [$this->issueTypeData()],
+            'total' => 1,
+            'maxResults' => 50,
+            'startAt' => 0,
+        ];
+
+        $collection = IssueTypes::make($data);
+
+        $this->assertSame($data, $collection->toArray(), 'IssueTypes::toArray() should return the same data passed to make()');
+    }
+
+    public function test_has_more(): void
+    {
+        $collection = IssueTypes::make(['issueTypes' => [], 'total' => 10, 'maxResults' => 5, 'startAt' => 0]);
+
+        $this->assertTrue($collection->hasMore(), 'hasMore() should return true when more pages exist');
+    }
+}

--- a/tests/Models/ProjectsTest.php
+++ b/tests/Models/ProjectsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Project;
+use CaptureHigherEd\LaravelJira\Models\Projects;
+use PHPUnit\Framework\TestCase;
+
+class ProjectsTest extends TestCase
+{
+    public function test_make_with_empty_data(): void
+    {
+        $projects = Projects::make();
+
+        $this->assertSame([], $projects->getProjects(), 'Projects should default to an empty array when not provided');
+    }
+
+    public function test_make_hydrates_projects(): void
+    {
+        $data = [
+            ['id' => '10000', 'key' => 'TEST', 'name' => 'Test Project', 'self' => '', 'projectTypeKey' => 'software', 'simplified' => false, 'avatarUrls' => []],
+            ['id' => '10001', 'key' => 'DEMO', 'name' => 'Demo Project', 'self' => '', 'projectTypeKey' => 'business', 'simplified' => true, 'avatarUrls' => []],
+        ];
+
+        $projects = Projects::make($data);
+
+        $this->assertCount(2, $projects->getProjects(), 'Projects should hydrate the correct number of items');
+        $this->assertInstanceOf(Project::class, $projects->getProjects()[0], 'Each project item should be a Project instance');
+        $this->assertSame('TEST', $projects->getProjects()[0]->getKey(), 'First project key should be hydrated correctly');
+    }
+
+    public function test_to_array(): void
+    {
+        $data = [
+            ['id' => '10000', 'key' => 'TEST', 'name' => 'Test Project', 'self' => '', 'projectTypeKey' => 'software', 'simplified' => false, 'avatarUrls' => []],
+        ];
+
+        $projects = Projects::make($data);
+
+        $this->assertSame($data, $projects->toArray(), 'Projects::toArray() should return the original data array');
+    }
+}

--- a/tests/Models/SearchTest.php
+++ b/tests/Models/SearchTest.php
@@ -3,6 +3,7 @@
 namespace CaptureHigherEd\LaravelJira\Tests\Models;
 
 use CaptureHigherEd\LaravelJira\Models\Issue;
+use CaptureHigherEd\LaravelJira\Models\Paginated;
 use CaptureHigherEd\LaravelJira\Models\Search;
 use PHPUnit\Framework\TestCase;
 
@@ -48,5 +49,40 @@ class SearchTest extends TestCase
         foreach ($search->getIssues() as $issue) {
             $this->assertInstanceOf(Issue::class, $issue, 'Each item in the search results should be hydrated as an Issue instance');
         }
+    }
+
+    // ── pagination ────────────────────────────────────────────────────────
+
+    public function test_implements_paginated(): void
+    {
+        $this->assertInstanceOf(Paginated::class, Search::make(), 'Search should implement the Paginated interface');
+    }
+
+    public function test_make_hydrates_pagination(): void
+    {
+        $search = Search::make([
+            'issues' => [],
+            'total' => 42,
+            'maxResults' => 10,
+            'startAt' => 20,
+        ]);
+
+        $this->assertSame(42, $search->getTotal(), 'Search should hydrate total from response data');
+        $this->assertSame(10, $search->getMaxResults(), 'Search should hydrate maxResults from response data');
+        $this->assertSame(20, $search->getStartAt(), 'Search should hydrate startAt from response data');
+    }
+
+    public function test_has_more(): void
+    {
+        $search = Search::make(['issues' => [], 'total' => 100, 'maxResults' => 50, 'startAt' => 0]);
+
+        $this->assertTrue($search->hasMore(), 'hasMore() should return true when more pages exist');
+    }
+
+    public function test_has_more_false_on_last_page(): void
+    {
+        $search = Search::make(['issues' => [], 'total' => 100, 'maxResults' => 50, 'startAt' => 50]);
+
+        $this->assertFalse($search->hasMore(), 'hasMore() should return false on the last page');
     }
 }

--- a/tests/Models/TransitionTest.php
+++ b/tests/Models/TransitionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Status;
+use CaptureHigherEd\LaravelJira\Models\Transition;
+use PHPUnit\Framework\TestCase;
+
+class TransitionTest extends TestCase
+{
+    public function test_make_with_empty_data(): void
+    {
+        $transition = Transition::make();
+
+        $this->assertSame('', $transition->getId(), 'Transition ID should default to an empty string when not provided');
+        $this->assertSame('', $transition->getName(), 'Transition name should default to an empty string when not provided');
+        $this->assertNull($transition->getTo(), 'Transition to-status should default to null when not provided');
+        $this->assertFalse($transition->getHasScreen(), 'Transition hasScreen should default to false when not provided');
+        $this->assertFalse($transition->getIsGlobal(), 'Transition isGlobal should default to false when not provided');
+        $this->assertFalse($transition->getIsInitial(), 'Transition isInitial should default to false when not provided');
+        $this->assertFalse($transition->getIsConditional(), 'Transition isConditional should default to false when not provided');
+    }
+
+    public function test_make_roundtrip(): void
+    {
+        $data = [
+            'id' => '5',
+            'name' => 'In Progress',
+            'to' => [
+                'id' => '3',
+                'name' => 'In Progress',
+                'description' => '',
+                'iconUrl' => '',
+                'self' => '',
+                'statusCategory' => [],
+            ],
+            'hasScreen' => false,
+            'isGlobal' => true,
+            'isInitial' => false,
+            'isConditional' => false,
+        ];
+
+        $transition = Transition::make($data);
+
+        $this->assertSame($data, $transition->toArray(), 'Transition::toArray() should return the same data passed to make()');
+    }
+
+    public function test_to_status_is_hydrated(): void
+    {
+        $transition = Transition::make([
+            'id' => '1',
+            'name' => 'Done',
+            'to' => ['id' => '10000', 'name' => 'Done', 'description' => '', 'iconUrl' => '', 'self' => '', 'statusCategory' => []],
+        ]);
+
+        $this->assertInstanceOf(Status::class, $transition->getTo(), 'Transition to-status should be hydrated as a Status instance');
+        $this->assertSame('10000', $transition->getTo()?->getId(), 'Transition to-status ID should be hydrated correctly');
+    }
+
+    public function test_make_without_to_returns_null(): void
+    {
+        $transition = Transition::make(['id' => '1', 'name' => 'Done']);
+
+        $this->assertNull($transition->getTo(), 'Transition to-status should be null when not present in data');
+    }
+}

--- a/tests/Models/TransitionsTest.php
+++ b/tests/Models/TransitionsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Transition;
+use CaptureHigherEd\LaravelJira\Models\Transitions;
+use PHPUnit\Framework\TestCase;
+
+class TransitionsTest extends TestCase
+{
+    public function test_make_with_empty_data(): void
+    {
+        $transitions = Transitions::make();
+
+        $this->assertSame([], $transitions->getTransitions(), 'Transitions should default to an empty array when not provided');
+    }
+
+    public function test_make_hydrates_transitions(): void
+    {
+        $data = [
+            'transitions' => [
+                ['id' => '1', 'name' => 'To Do', 'hasScreen' => false, 'isGlobal' => false, 'isInitial' => true, 'isConditional' => false],
+                ['id' => '2', 'name' => 'In Progress', 'hasScreen' => false, 'isGlobal' => true, 'isInitial' => false, 'isConditional' => false],
+            ],
+        ];
+
+        $transitions = Transitions::make($data);
+
+        $this->assertCount(2, $transitions->getTransitions(), 'Transitions should hydrate the correct number of items');
+        $this->assertInstanceOf(Transition::class, $transitions->getTransitions()[0], 'Each transition item should be a Transition instance');
+        $this->assertSame('1', $transitions->getTransitions()[0]->getId(), 'First transition ID should be hydrated correctly');
+    }
+
+    public function test_to_array_returns_flat_list(): void
+    {
+        $data = [
+            'transitions' => [
+                ['id' => '5', 'name' => 'Done', 'hasScreen' => false, 'isGlobal' => true, 'isInitial' => false, 'isConditional' => false],
+            ],
+        ];
+
+        $transitions = Transitions::make($data);
+        $array = $transitions->toArray();
+
+        $this->assertCount(1, $array, 'Transitions::toArray() should return a flat array of transition arrays');
+        $this->assertSame('5', $array[0]['id'], 'Transitions::toArray() should preserve the transition ID');
+    }
+}

--- a/tests/Models/WatchersTest.php
+++ b/tests/Models/WatchersTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\User;
+use CaptureHigherEd\LaravelJira\Models\Watchers;
+use PHPUnit\Framework\TestCase;
+
+class WatchersTest extends TestCase
+{
+    public function test_make_with_empty_data(): void
+    {
+        $watchers = Watchers::make();
+
+        $this->assertSame('', $watchers->getSelf(), 'Watchers self URL should default to an empty string when not provided');
+        $this->assertFalse($watchers->getIsWatching(), 'Watchers isWatching should default to false when not provided');
+        $this->assertSame(0, $watchers->getWatchCount(), 'Watchers watchCount should default to 0 when not provided');
+        $this->assertSame([], $watchers->getWatchers(), 'Watchers list should default to an empty array when not provided');
+    }
+
+    public function test_make_roundtrip(): void
+    {
+        $userData = [
+            'accountId' => 'u1',
+            'displayName' => 'Alice',
+            'emailAddress' => 'alice@example.com',
+            'active' => true,
+            'self' => '',
+            'accountType' => '',
+            'timeZone' => '',
+            'locale' => '',
+            'avatarUrls' => [],
+        ];
+        $data = [
+            'self' => 'https://example.atlassian.net/rest/api/3/issue/KEY-1/watchers',
+            'isWatching' => true,
+            'watchCount' => 1,
+            'watchers' => [$userData],
+        ];
+
+        $watchers = Watchers::make($data);
+
+        $this->assertSame($data, $watchers->toArray(), 'Watchers::toArray() should return the same data passed to make()');
+    }
+
+    public function test_watchers_are_hydrated_as_users(): void
+    {
+        $data = [
+            'self' => '',
+            'isWatching' => false,
+            'watchCount' => 2,
+            'watchers' => [
+                ['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => '', 'active' => true],
+                ['accountId' => 'u2', 'displayName' => 'Bob', 'emailAddress' => '', 'active' => false],
+            ],
+        ];
+
+        $watchers = Watchers::make($data);
+
+        $this->assertCount(2, $watchers->getWatchers(), 'Watchers list should contain the correct number of users');
+        $this->assertInstanceOf(User::class, $watchers->getWatchers()[0], 'Each watcher should be a User instance');
+        $this->assertSame('u1', $watchers->getWatchers()[0]->getKey(), 'First watcher accountId should be hydrated correctly');
+    }
+}

--- a/tests/Models/WorklogTest.php
+++ b/tests/Models/WorklogTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\User;
+use CaptureHigherEd\LaravelJira\Models\Worklog;
+use PHPUnit\Framework\TestCase;
+
+class WorklogTest extends TestCase
+{
+    public function test_make_with_empty_data(): void
+    {
+        $worklog = Worklog::make();
+
+        $this->assertSame('', $worklog->getId(), 'Worklog ID should default to an empty string when not provided');
+        $this->assertSame('', $worklog->getSelf(), 'Worklog self URL should default to an empty string when not provided');
+        $this->assertNull($worklog->getAuthor(), 'Worklog author should default to null when not provided');
+        $this->assertNull($worklog->getUpdateAuthor(), 'Worklog updateAuthor should default to null when not provided');
+        $this->assertSame([], $worklog->getComment(), 'Worklog comment should default to an empty array when not provided');
+        $this->assertSame('', $worklog->getStarted(), 'Worklog started should default to an empty string when not provided');
+        $this->assertSame('', $worklog->getTimeSpent(), 'Worklog timeSpent should default to an empty string when not provided');
+        $this->assertSame(0, $worklog->getTimeSpentSeconds(), 'Worklog timeSpentSeconds should default to 0 when not provided');
+        $this->assertSame('', $worklog->getIssueId(), 'Worklog issueId should default to an empty string when not provided');
+        $this->assertSame('', $worklog->getCreated(), 'Worklog created should default to an empty string when not provided');
+        $this->assertSame('', $worklog->getUpdated(), 'Worklog updated should default to an empty string when not provided');
+    }
+
+    public function test_make_roundtrip(): void
+    {
+        $userData = [
+            'accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => 'alice@example.com',
+            'active' => true, 'self' => '', 'accountType' => '', 'timeZone' => '', 'locale' => '', 'avatarUrls' => [],
+        ];
+        $data = [
+            'id' => '10100',
+            'self' => 'https://example.atlassian.net/rest/api/3/issue/KEY-1/worklog/10100',
+            'author' => $userData,
+            'updateAuthor' => $userData,
+            'comment' => ['type' => 'doc', 'version' => 1, 'content' => []],
+            'started' => '2024-01-01T09:00:00.000+0000',
+            'timeSpent' => '2h',
+            'timeSpentSeconds' => 7200,
+            'issueId' => '10001',
+            'created' => '2024-01-01T09:00:00.000+0000',
+            'updated' => '2024-01-01T09:00:00.000+0000',
+        ];
+
+        $worklog = Worklog::make($data);
+
+        $this->assertSame($data, $worklog->toArray(), 'Worklog::toArray() should return the same data passed to make()');
+    }
+
+    public function test_author_is_hydrated_as_user(): void
+    {
+        $worklog = Worklog::make([
+            'author' => ['accountId' => 'u1', 'displayName' => 'Alice', 'emailAddress' => '', 'active' => true],
+        ]);
+
+        $this->assertInstanceOf(User::class, $worklog->getAuthor(), 'Worklog author should be hydrated as a User instance');
+        $this->assertSame('u1', $worklog->getAuthor()?->getKey(), 'Worklog author accountId should be hydrated correctly');
+    }
+}

--- a/tests/Models/WorklogsTest.php
+++ b/tests/Models/WorklogsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Models;
+
+use CaptureHigherEd\LaravelJira\Models\Worklog;
+use CaptureHigherEd\LaravelJira\Models\Worklogs;
+use PHPUnit\Framework\TestCase;
+
+class WorklogsTest extends TestCase
+{
+    public function test_make_with_empty_data(): void
+    {
+        $collection = Worklogs::make();
+
+        $this->assertSame([], $collection->getWorklogs(), 'Worklogs should default to an empty worklogs array when not provided');
+        $this->assertSame(0, $collection->getTotal(), 'Worklogs total should default to 0 when not provided');
+        $this->assertSame(0, $collection->getMaxResults(), 'Worklogs maxResults should default to 0 when not provided');
+        $this->assertSame(0, $collection->getStartAt(), 'Worklogs startAt should default to 0 when not provided');
+    }
+
+    public function test_make_hydrates_worklogs_and_pagination(): void
+    {
+        $data = [
+            'worklogs' => [
+                ['id' => '1', 'self' => '', 'author' => null, 'updateAuthor' => null, 'comment' => [], 'started' => '', 'timeSpent' => '1h', 'timeSpentSeconds' => 3600, 'issueId' => '10001', 'created' => '', 'updated' => ''],
+            ],
+            'total' => 5,
+            'maxResults' => 20,
+            'startAt' => 0,
+        ];
+
+        $collection = Worklogs::make($data);
+
+        $this->assertCount(1, $collection->getWorklogs(), 'Worklogs should hydrate the correct number of worklogs');
+        $this->assertInstanceOf(Worklog::class, $collection->getWorklogs()[0], 'Each worklog should be hydrated as a Worklog instance');
+        $this->assertSame(5, $collection->getTotal(), 'Worklogs total should be hydrated correctly');
+        $this->assertSame('1h', $collection->getWorklogs()[0]->getTimeSpent(), 'Worklog timeSpent should be hydrated correctly');
+    }
+
+    public function test_to_array_roundtrip(): void
+    {
+        $data = [
+            'worklogs' => [
+                ['id' => '1', 'self' => '', 'author' => null, 'updateAuthor' => null, 'comment' => [], 'started' => '', 'timeSpent' => '2h', 'timeSpentSeconds' => 7200, 'issueId' => '10001', 'created' => '', 'updated' => ''],
+            ],
+            'total' => 1,
+            'maxResults' => 20,
+            'startAt' => 0,
+        ];
+
+        $collection = Worklogs::make($data);
+
+        $this->assertSame($data, $collection->toArray(), 'Worklogs::toArray() should return the same data passed to make()');
+    }
+}


### PR DESCRIPTION
Adds 5 new API classes (Attachments, Comments, IssueLinks, Projects, Worklogs) with full CRUD coverage and supporting models. Introduces an abstract `Model` base class with PHP 8.1 constructor promotion, eliminating ~400 lines of repetitive boilerplate across all 27 models.

___

### Changes
- Add `Api/Attachments`, `Api/Comments`, `Api/IssueLinks`, `Api/Projects`, `Api/Worklogs` API classes
- Add `httpDelete($path, $params)` query parameter support to `HttpApi`
- Add new models: `Transition`, `Transitions`, `Projects`, `Watchers`, `Comment` (collection), `Worklog`, `Worklogs`, `IssueLink`, `IssueLinkType`, `IssueLinkTypes`
- Introduce abstract `Models/Model` base class implementing `ApiResponse`
- Refactor all 27 models to `extend Model` with PHP 8.1 constructor promotion and remove `const` declarations
- Expose all new API classes via `Jira.php` entry point (`projects()`, `comments()`, `worklogs()`, `issueLinks()`, `attachments()`)
- Add 199 passing tests covering all new and modified classes