### PR TITLE
Library Improvements: network exceptions, trait extraction, HttpClient, strict_types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,26 +47,34 @@
 * [2.x] Remove `Field::getOptions()` — use `Api\Fields::getFieldOptions()` instead by [@mpetty](https://github.com/mpetty)
 * [2.x] Remove all model `const` declarations by [@mpetty](https://github.com/mpetty)
 
-## [v1.0.5](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.4...v1.0.5) - 2025-09-02
+## [v1.2.0](https://github.com/CaptureHigherEd/Laravel-Jira/compare/1.1.0...1.2.0) - 2025-09-03
 
-* [1.x] Add `$is_multi_select` parameter to `Issue::setCustomFieldByValue()` by [@mpetty](https://github.com/mpetty)
+* [1.x] Update Laravel compatibility to support >= 8 by [@mpetty](https://github.com/mpetty)
+
+## [v1.1.0](https://github.com/CaptureHigherEd/Laravel-Jira/compare/1.0.5...1.1.0) - 2024-04-11
+
+* [1.x] Update allowed versions of Laravel (8, 9, 10, 11) by [@mpetty](https://github.com/mpetty) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/4
+
+## [v1.0.5](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.4...1.0.5) - 2023-12-27
+
+* [1.x] Add `$is_multi_select` parameter to `Issue::setCustomFieldByValue()` by [@adugatkin](https://github.com/adugatkin) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/2
 
 ## [v1.0.4](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.3...v1.0.4) - 2023-07-17
 
-* [1.x] Minor fix to `Issues.php` by [@mpetty](https://github.com/mpetty)
+* [1.x] Minor fix to `Issues.php` by [@adugatkin](https://github.com/adugatkin)
 
-## [v1.0.3](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.2...v1.0.3) - 2023-06-01
+## [v1.0.3](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.2...v1.0.3) - 2023-07-13
 
-* [1.x] Remove hardcoded values; issue link URL now generated from config by [@mpetty](https://github.com/mpetty)
+* [1.x] Updates to allow for further flexibility and functionality by [@adugatkin](https://github.com/adugatkin) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/1
 
-## [v1.0.2](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.1...v1.0.2) - 2023-01-01
+## [v1.0.2](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.1...v1.0.2) - 2023-06-27
 
-* [1.x] Update `composer.json` by [@mpetty](https://github.com/mpetty)
+* [1.x] Update `composer.json` by [@adugatkin](https://github.com/adugatkin)
 
-## [v1.0.1](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.0...v1.0.1) - 2023-01-01
+## [v1.0.1](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.0...v1.0.1) - 2023-06-20
 
-* [1.x] Initial public release updates by [@mpetty](https://github.com/mpetty)
+* [1.x] Initial public release updates by [@adugatkin](https://github.com/adugatkin)
 
-## v1.0.0 - 2023-01-01
+## v1.0.0 - 2023-06-20
 
-* Initial release by [@mpetty](https://github.com/mpetty)
+* Initial release by [@adugatkin](https://github.com/adugatkin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Api\HttpClient` — escape hatch for arbitrary Jira API calls not yet covered by a specific `Api` class; accessible via `Jira::httpClient()`
+- `Jira::httpClient(): Api\HttpClient` — entry point for the raw HTTP escape hatch
+- `HttpServerException::networkError(\Throwable $previous): self` — wraps PSR-18 `NetworkExceptionInterface` transport failures (timeouts, DNS, connection reset); `getResponseCode()` returns `0`, `getResponse()` returns `null`
+- `HttpServerException::unknownHttpResponseCode(ResponseInterface $response): self` — thrown for unexpected non-4xx responses in the default `handleErrors()` branch
+- `Exception\Concerns\ParsesResponseBody` trait — shared response-body parsing logic (rewind, read, JSON decode, content-type check) extracted from both exception classes; also provides `getResponse()`, `getResponseBody()`, `getResponseCode()`
 - `Attachment` and `Attachments` models with full `make()` / `toArray()` support
 - `Comment` model with full `make()` / `toArray()` support
 - `Api\Fields::getFieldOptions(Field $field, string $projectKey, string $issueTypeName): array` — replaces `Field::getOptions()`
@@ -53,6 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `HttpClientException` constructor now rewinds the response body stream before reading, preventing double-consume
 - Guzzle requests now use `['json' => $params]` instead of `['body' => json_encode($params)]`
 - Service provider now returns `null` when `jira.token` is not set instead of throwing a `RuntimeException`
+- PSR-18 `NetworkExceptionInterface` (transport-level failures) was previously unhandled; all `sendRequest()` calls now catch it and rethrow as `HttpServerException::networkError()`
+- `handleErrors()` default branch now correctly classifies unrecognized 4xx codes as `HttpClientException` and routes all other unrecognized codes to `HttpServerException::unknownHttpResponseCode()` — previously all unrecognized codes threw `HttpClientException`
 
 ### Changed
 
@@ -63,6 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All 27 models refactored: constructor promotion, `const` declarations removed, `make()` uses named args
 - Collection models use `array_map` instead of `foreach` loops
 - `Issues::search()` migrated to `/rest/api/3/search/jql` endpoint
+- `HttpClientConnector` and `Http\RequestBuilder` are now marked `final`
+- `declare(strict_types=1)` added to all source files
+- `str_starts_with()` replaces `strpos(...) !== 0` in exception classes (PHP 8.1+)
 
 ## [1.0.5] - 2025-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,120 +1,72 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+## [Unreleased](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v2.0.0...HEAD)
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [v2.0.0](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.5...v2.0.0) - Unreleased
 
-## [Unreleased]
+* [2.x] Add `Api\HttpClient` escape hatch for arbitrary API calls; expose via `Jira::httpClient()` by [@mpetty](https://github.com/mpetty) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/17
+* [2.x] Add `HttpServerException::networkError()` factory to wrap PSR-18 `NetworkExceptionInterface` transport failures by [@mpetty](https://github.com/mpetty) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/17
+* [2.x] Add `HttpServerException::unknownHttpResponseCode()` factory for unrecognized non-4xx responses by [@mpetty](https://github.com/mpetty) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/17
+* [2.x] Extract `Exception\Concerns\ParsesResponseBody` trait to eliminate duplicated body-parsing logic across exception classes by [@mpetty](https://github.com/mpetty) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/17
+* [2.x] Catch `NetworkExceptionInterface` in all `sendRequest()` calls and rethrow as `HttpServerException::networkError()` by [@mpetty](https://github.com/mpetty) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/17
+* [2.x] Fix `handleErrors()` default branch to route unknown 4xx codes to `HttpClientException` and all other unrecognized codes to `HttpServerException` by [@mpetty](https://github.com/mpetty) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/17
+* [2.x] Mark `HttpClientConnector` and `Http\RequestBuilder` as `final` by [@mpetty](https://github.com/mpetty) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/17
+* [2.x] Add `declare(strict_types=1)` to all source files by [@mpetty](https://github.com/mpetty) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/17
+* [2.x] Replace `strpos(...) !== 0` with `str_starts_with()` throughout exception classes by [@mpetty](https://github.com/mpetty) in https://github.com/CaptureHigherEd/Laravel-Jira/pull/17
+* [2.x] Add `Api\Projects` with `index()` and `show()` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Api\Comments` with `index()`, `show()`, `create()`, `update()`, `delete()` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Api\Worklogs` with `index()`, `create()`, `update()`, `delete()` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Api\IssueLinks` with `create()`, `show()`, `delete()`, `getTypes()` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Api\Attachments` with `show()`, `delete()`, `getMeta()` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Api\Fields::getLabels()` for label retrieval by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Issues::getTransitions()`, `transition()`, `assign()`, `getWatchers()`, `addWatcher()`, `removeWatcher()` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Users::search()` and `myself()` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Jira` entry point methods: `projects()`, `comments()`, `worklogs()`, `issueLinks()`, `attachments()` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Paginated` interface, `HasPagination` trait, and `HttpApi::paginateGet()` generator for automatic pagination by [@mpetty](https://github.com/mpetty)
+* [2.x] Add 10 new models: `Transition`, `Transitions`, `Projects`, `Watchers`, `Comments`, `Worklog`, `Worklogs`, `IssueLink`, `IssueLinkType`, `IssueLinkTypes` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Attachment` and `Attachments` models by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Comment` model by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `FieldMeta` and `FieldMetas` models for createmeta responses by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `IssueTypes` collection model by [@mpetty](https://github.com/mpetty)
+* [2.x] Add abstract `Model` base class implementing `ApiResponse` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add typed getters to `Issue` for nested models (`getStatus()`, `getAssignee()`, `getReporter()`, etc.) by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `Api\Fields::getFieldOptions()` replacing removed `Field::getOptions()` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `toArray()` to `Field`, `Fields`, `Search`, `User`, `Users` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add HTTP error handling for status codes 422, 500, 502, 503 by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `HttpApi::httpDelete()` query parameter support by [@mpetty](https://github.com/mpetty)
+* [2.x] Add CI matrix via GitHub Actions: PHP 8.2 / 8.3 / 8.4 × Laravel 10 / 11 / 12 by [@mpetty](https://github.com/mpetty)
+* [2.x] Add `getLastResponse(): ?ResponseInterface` to `HttpApi` by [@mpetty](https://github.com/mpetty)
+* [2.x] Migrate to PSR-18 HTTP client with `HttpClientConfig`, `RequestBuilder`, and `HttpClientConnector` by [@mpetty](https://github.com/mpetty)
+* [2.x] Add hydrator strategy pattern: `ModelHydrator`, `ArrayHydrator`, `NoopHydrator` by [@mpetty](https://github.com/mpetty)
+* [2.x] Raise PHP minimum from `^8.0.2` to `^8.1` and Laravel minimum from `^8.0||^9.0` to `^10.0||^11.0||^12.0` by [@mpetty](https://github.com/mpetty)
+* [2.x] Fix `array_filter` on issue fields to preserve falsy non-null values (`0`, `''`, `false`) by [@mpetty](https://github.com/mpetty)
+* [2.x] Fix `HttpClientException` constructor to rewind response body before reading by [@mpetty](https://github.com/mpetty)
+* [2.x] Fix Guzzle requests to use `['json' => $params]` instead of `['body' => json_encode($params)]` by [@mpetty](https://github.com/mpetty)
+* [2.x] Fix service provider to return `null` instead of throwing `RuntimeException` when API token is unset by [@mpetty](https://github.com/mpetty)
+* [2.x] Migrate `Issues::search()` to `/rest/api/3/search/jql` endpoint by [@mpetty](https://github.com/mpetty)
+* [2.x] Remove `Field::getOptions()` — use `Api\Fields::getFieldOptions()` instead by [@mpetty](https://github.com/mpetty)
+* [2.x] Remove all model `const` declarations by [@mpetty](https://github.com/mpetty)
 
-## [2.0.0] - Unreleased
+## [v1.0.5](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.4...v1.0.5) - 2025-09-02
 
-### Breaking Changes
+* [1.x] Add `$is_multi_select` parameter to `Issue::setCustomFieldByValue()` by [@mpetty](https://github.com/mpetty)
 
-- **`Issues::attach()` return type changed** from `Issue` to `Attachments` — update any code that accesses the returned object
-- **`Issues::comment()` return type changed** from `Issue` to `Comment` — update any code that accesses the returned object
-- **`Field::getOptions()` removed** — use `Api\Fields::getFieldOptions(Field $field, string $projectKey, string $issueTypeName)` instead
-- **PHP minimum version raised** from `^8.0.2` to `^8.1`
-- **Laravel minimum version raised** from `^8.0||^9.0` to `^10.0||^11.0||^12.0`
-- **`Issues::comment()` now delegates to `Comments::create()`** — behavior unchanged but internal routing differs
-- **All model `const` declarations removed** — any code referencing e.g. `User::NAME` or `Issue::FIELDS` must use string literals
-- **All models now extend `Model` base class** instead of implementing `ApiResponse` directly
+## [v1.0.4](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.3...v1.0.4) - 2023-07-17
 
-### Added
+* [1.x] Minor fix to `Issues.php` by [@mpetty](https://github.com/mpetty)
 
-- `Api\HttpClient` — escape hatch for arbitrary Jira API calls not yet covered by a specific `Api` class; accessible via `Jira::httpClient()`
-- `Jira::httpClient(): Api\HttpClient` — entry point for the raw HTTP escape hatch
-- `HttpServerException::networkError(\Throwable $previous): self` — wraps PSR-18 `NetworkExceptionInterface` transport failures (timeouts, DNS, connection reset); `getResponseCode()` returns `0`, `getResponse()` returns `null`
-- `HttpServerException::unknownHttpResponseCode(ResponseInterface $response): self` — thrown for unexpected non-4xx responses in the default `handleErrors()` branch
-- `Exception\Concerns\ParsesResponseBody` trait — shared response-body parsing logic (rewind, read, JSON decode, content-type check) extracted from both exception classes; also provides `getResponse()`, `getResponseBody()`, `getResponseCode()`
-- `Attachment` and `Attachments` models with full `make()` / `toArray()` support
-- `Comment` model with full `make()` / `toArray()` support
-- `Api\Fields::getFieldOptions(Field $field, string $projectKey, string $issueTypeName): array` — replaces `Field::getOptions()`
-- `toArray()` implemented on `Field`, `Fields`, `Search`, `User`, `Users`
-- HTTP error handling for status codes 422 (Unprocessable Entity), 500, 502, 503
-- CI matrix via GitHub Actions: PHP 8.2 / 8.3 / 8.4 × Laravel 10 / 11 / 12
-- PHPStan (level 6) and Pint (Laravel preset) configuration
-- Comprehensive test suite: 115 tests across models, API classes, exceptions, and the service provider
-- `Api\Projects` — `index()`, `show()`
-- `Api\Comments` — `index()`, `show()`, `create()`, `update()`, `delete()`
-- `Api\Worklogs` — `index()`, `create()`, `update()`, `delete()`
-- `Api\IssueLinks` — `create()`, `show()`, `delete()`, `getTypes()`
-- `Api\Attachments` — `show()`, `delete()`, `getMeta()`
-- `Api\Fields::getLabels()` for label retrieval
-- `Issues::getTransitions()`, `transition()`, `assign()`, `getWatchers()`, `addWatcher()`, `removeWatcher()`
-- `Users::search()`, `myself()`
-- `Jira` entry point methods: `projects()`, `comments()`, `worklogs()`, `issueLinks()`, `attachments()`
-- 10 new models: `Transition`, `Transitions`, `Projects`, `Watchers`, `Comments` (collection), `Worklog`, `Worklogs`, `IssueLink`, `IssueLinkType`, `IssueLinkTypes`
-- Abstract `Model` base class implementing `ApiResponse`
-- `Issue` typed getters: `getStatus()`, `getAssignee()`, `getReporter()`, `getPriority()`, `getIssueType()`, `getProject()`, `getResolution()`, etc.
-- `FieldMeta` and `FieldMetas` models for createmeta responses
-- `IssueTypes` collection model
-- `HttpApi::httpDelete()` now accepts query parameters
-- Test suite expanded to 199 tests
+## [v1.0.3](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.2...v1.0.3) - 2023-06-01
 
-### Fixed
+* [1.x] Remove hardcoded values; issue link URL now generated from config by [@mpetty](https://github.com/mpetty)
 
-- `array_filter` on issue fields now preserves falsy non-null values (`0`, `''`, `false`) — previously dropped them
-- `HttpClientException` constructor now rewinds the response body stream before reading, preventing double-consume
-- Guzzle requests now use `['json' => $params]` instead of `['body' => json_encode($params)]`
-- Service provider now returns `null` when `jira.token` is not set instead of throwing a `RuntimeException`
-- PSR-18 `NetworkExceptionInterface` (transport-level failures) was previously unhandled; all `sendRequest()` calls now catch it and rethrow as `HttpServerException::networkError()`
-- `handleErrors()` default branch now correctly classifies unrecognized 4xx codes as `HttpClientException` and routes all other unrecognized codes to `HttpServerException::unknownHttpResponseCode()` — previously all unrecognized codes threw `HttpClientException`
+## [v1.0.2](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.1...v1.0.2) - 2023-01-01
 
-### Changed
+* [1.x] Update `composer.json` by [@mpetty](https://github.com/mpetty)
 
-- All model getters and setters are now fully typed
-- `User::$active` is now strictly typed as `bool`
-- `HttpApi` constructor now accepts `GuzzleHttp\ClientInterface` (PSR) instead of the concrete `Client`
-- All `HttpClientException` factory methods now declare `self` as their return type
-- All 27 models refactored: constructor promotion, `const` declarations removed, `make()` uses named args
-- Collection models use `array_map` instead of `foreach` loops
-- `Issues::search()` migrated to `/rest/api/3/search/jql` endpoint
-- `HttpClientConnector` and `Http\RequestBuilder` are now marked `final`
-- `declare(strict_types=1)` added to all source files
-- `str_starts_with()` replaces `strpos(...) !== 0` in exception classes (PHP 8.1+)
+## [v1.0.1](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.0...v1.0.1) - 2023-01-01
 
-## [1.0.5] - 2025-09-02
+* [1.x] Initial public release updates by [@mpetty](https://github.com/mpetty)
 
-### Added
+## v1.0.0 - 2023-01-01
 
-- `Issue::setCustomFieldByValue()` now accepts a `$is_multi_select` parameter to control single vs. multi-select field format
-
-## [1.0.4] - 2023-07-17
-
-### Fixed
-
-- Minor fix to `Issues.php`
-
-## [1.0.3] - 2023-06-xx
-
-### Changed
-
-- Removed hardcoded values; issue link URL is now generated from config
-
-## [1.0.2] - 2023-xx-xx
-
-### Changed
-
-- `composer.json` updates
-
-## [1.0.1] - 2023-xx-xx
-
-### Changed
-
-- Initial public release updates
-
-## [1.0.0] - 2023-xx-xx
-
-### Added
-
-- Initial release
-
-[Unreleased]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/2.0.0...HEAD
-[2.0.0]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/1.0.5...2.0.0
-[1.0.5]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.4...1.0.5
-[1.0.4]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.3...v1.0.4
-[1.0.3]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/CaptureHigherEd/Laravel-Jira/releases/tag/v1.0.0
+* Initial release by [@mpetty](https://github.com/mpetty)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v2.0.0...HEAD)
+## [Unreleased](https://github.com/CaptureHigherEd/Laravel-Jira/compare/1.2.0...HEAD)
 
 ## [v2.0.0](https://github.com/CaptureHigherEd/Laravel-Jira/compare/v1.0.5...v2.0.0) - Unreleased
 

--- a/README.md
+++ b/README.md
@@ -360,9 +360,41 @@ foreach ($jira->issues()->paginate(['jql' => 'project = PROJ']) as $page) {
 
 ---
 
+### Raw HTTP Access
+
+For Jira endpoints not yet covered by a specific API class, use the `httpClient()` escape hatch. All methods return the raw PSR-7 `ResponseInterface`:
+
+```php
+use Psr\Http\Message\ResponseInterface;
+
+// GET any endpoint
+$response = $jira->httpClient()->httpGet('issue/PROJ-123/subtasks');
+
+// POST with a JSON body
+$response = $jira->httpClient()->httpPost('issue', ['fields' => [/* ... */]]);
+
+// PUT, DELETE, raw POST also available
+$response = $jira->httpClient()->httpPut('issue/PROJ-123', ['fields' => [/* ... */]]);
+$response = $jira->httpClient()->httpDelete('issue/PROJ-123');
+```
+
+---
+
 ## Error Handling
 
-All HTTP errors throw `CaptureHigherEd\LaravelJira\Exception\HttpClientException`:
+All exceptions implement `CaptureHigherEd\LaravelJira\Exception\JiraException`, so you can catch everything with a single type:
+
+```php
+use CaptureHigherEd\LaravelJira\Exception\JiraException;
+
+try {
+    $issue = $jira->issues()->show('PROJ-123');
+} catch (JiraException $e) {
+    // catches 4xx, 5xx, and network failures
+}
+```
+
+**4xx client errors** throw `HttpClientException`:
 
 ```php
 use CaptureHigherEd\LaravelJira\Exception\HttpClientException;
@@ -376,7 +408,24 @@ try {
 }
 ```
 
-Covered status codes: 400, 401, 402, 403, 404, 409, 413, 422, 429, 500, 502, 503.
+**5xx server errors and network failures** throw `HttpServerException`:
+
+```php
+use CaptureHigherEd\LaravelJira\Exception\HttpServerException;
+
+try {
+    $issue = $jira->issues()->show('PROJ-123');
+} catch (HttpServerException $e) {
+    if ($e->getResponseCode() === 0) {
+        // Transport failure: timeout, DNS error, connection reset, etc.
+        echo $e->getMessage(); // A network error occurred. Check connectivity and try again.
+    } else {
+        echo $e->getResponseCode(); // 500, 502, 503, etc.
+    }
+}
+```
+
+Both exception classes expose `getResponse(): ?ResponseInterface`, `getResponseBody(): array`, and `getResponseCode(): int`.
 
 ## License
 

--- a/src/CaptureHigherEd/LaravelJira/Api/Attachments.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Attachments.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Assert;

--- a/src/CaptureHigherEd/LaravelJira/Api/Comments.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Comments.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Assert;

--- a/src/CaptureHigherEd/LaravelJira/Api/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Fields.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Assert;

--- a/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/HttpApi.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Exception\HttpClientException;
@@ -7,6 +9,7 @@ use CaptureHigherEd\LaravelJira\Exception\HttpServerException;
 use CaptureHigherEd\LaravelJira\Http\HttpClientConfig;
 use CaptureHigherEd\LaravelJira\Models\ApiResponse;
 use CaptureHigherEd\LaravelJira\Models\Paginated;
+use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -30,7 +33,7 @@ abstract class HttpApi
             $this->config->requestBuilder->create('GET', $this->buildUri($path, $parameters))
         );
 
-        return $this->lastResponse = $this->config->httpClient->sendRequest($request);
+        return $this->lastResponse = $this->sendRequest($request);
     }
 
     /**
@@ -42,7 +45,7 @@ abstract class HttpApi
             $this->config->requestBuilder->createWithJson('POST', $this->buildUri($path), $parameters)
         );
 
-        return $this->lastResponse = $this->config->httpClient->sendRequest($request);
+        return $this->lastResponse = $this->sendRequest($request);
     }
 
     /**
@@ -54,7 +57,7 @@ abstract class HttpApi
             $this->config->requestBuilder->createWithMultipart('POST', $this->buildUri($path), $multipart)
         )->withHeader('X-Atlassian-Token', 'no-check');
 
-        return $this->lastResponse = $this->config->httpClient->sendRequest($request);
+        return $this->lastResponse = $this->sendRequest($request);
     }
 
     /**
@@ -66,7 +69,7 @@ abstract class HttpApi
             $this->config->requestBuilder->createWithRawBody('POST', $this->buildUri($path), $body, $contentType)
         );
 
-        return $this->lastResponse = $this->config->httpClient->sendRequest($request);
+        return $this->lastResponse = $this->sendRequest($request);
     }
 
     /**
@@ -78,7 +81,7 @@ abstract class HttpApi
             $this->config->requestBuilder->createWithJson('PUT', $this->buildUri($path), $parameters)
         );
 
-        return $this->lastResponse = $this->config->httpClient->sendRequest($request);
+        return $this->lastResponse = $this->sendRequest($request);
     }
 
     /**
@@ -90,7 +93,16 @@ abstract class HttpApi
             $this->config->requestBuilder->create('DELETE', $this->buildUri($path, $parameters))
         );
 
-        return $this->lastResponse = $this->config->httpClient->sendRequest($request);
+        return $this->lastResponse = $this->sendRequest($request);
+    }
+
+    private function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        try {
+            return $this->config->httpClient->sendRequest($request);
+        } catch (NetworkExceptionInterface $e) {
+            throw HttpServerException::networkError($e);
+        }
     }
 
     protected function handleErrors(ResponseInterface $response): void
@@ -121,10 +133,10 @@ abstract class HttpApi
             case 503:
                 throw HttpServerException::serverError($response);
             default:
-                if ($statusCode >= 500) {
-                    throw HttpServerException::serverError($response);
+                if ($statusCode >= 400 && $statusCode < 500) {
+                    throw HttpClientException::unknown($response);
                 }
-                throw HttpClientException::unknown($response);
+                throw HttpServerException::unknownHttpResponseCode($response);
         }
     }
 

--- a/src/CaptureHigherEd/LaravelJira/Api/HttpClient.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/HttpClient.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptureHigherEd\LaravelJira\Api;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Escape hatch for making arbitrary Jira API calls not yet covered by a specific Api class.
+ *
+ * Usage:
+ *   $jira->httpClient()->httpGet('issue/KEY-1/subtasks');
+ */
+class HttpClient extends HttpApi
+{
+    public function httpGet(string $path, array $parameters = []): ResponseInterface
+    {
+        return parent::httpGet($path, $parameters);
+    }
+
+    public function httpPost(string $path, array $parameters = []): ResponseInterface
+    {
+        return parent::httpPost($path, $parameters);
+    }
+
+    public function httpPut(string $path, array $parameters = []): ResponseInterface
+    {
+        return parent::httpPut($path, $parameters);
+    }
+
+    public function httpDelete(string $path, array $parameters = []): ResponseInterface
+    {
+        return parent::httpDelete($path, $parameters);
+    }
+
+    public function httpPostRaw(string $path, string $body, string $contentType = 'application/json'): ResponseInterface
+    {
+        return parent::httpPostRaw($path, $body, $contentType);
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Api/IssueLinks.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/IssueLinks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Assert;

--- a/src/CaptureHigherEd/LaravelJira/Api/Issues.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Issues.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Assert;

--- a/src/CaptureHigherEd/LaravelJira/Api/Projects.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Projects.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Assert;

--- a/src/CaptureHigherEd/LaravelJira/Api/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Users.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Assert;

--- a/src/CaptureHigherEd/LaravelJira/Api/Worklogs.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Worklogs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Api;
 
 use CaptureHigherEd\LaravelJira\Assert;

--- a/src/CaptureHigherEd/LaravelJira/Assert.php
+++ b/src/CaptureHigherEd/LaravelJira/Assert.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira;
 
 use CaptureHigherEd\LaravelJira\Exception\InvalidArgumentException;

--- a/src/CaptureHigherEd/LaravelJira/Exception/Concerns/ParsesResponseBody.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/Concerns/ParsesResponseBody.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptureHigherEd\LaravelJira\Exception\Concerns;
+
+use Psr\Http\Message\ResponseInterface;
+
+trait ParsesResponseBody
+{
+    private ?ResponseInterface $response;
+
+    /** @var array<string, mixed> */
+    private array $responseBody = [];
+
+    private int $responseCode;
+
+    private function parseResponse(?ResponseInterface $response): void
+    {
+        $this->response = $response;
+
+        if ($response === null) {
+            $this->responseCode = 0;
+
+            return;
+        }
+
+        $this->responseCode = $response->getStatusCode();
+
+        $response->getBody()->rewind();
+        $body = $response->getBody()->__toString();
+
+        if (! str_starts_with($response->getHeaderLine('Content-Type'), 'application/json')) {
+            $this->responseBody['message'] = $body;
+        } elseif ($body) {
+            $this->responseBody = json_decode($body, true) ?? [];
+        }
+    }
+
+    public function getResponse(): ?ResponseInterface
+    {
+        return $this->response;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getResponseBody(): array
+    {
+        return $this->responseBody;
+    }
+
+    public function getResponseCode(): int
+    {
+        return $this->responseCode;
+    }
+}

--- a/src/CaptureHigherEd/LaravelJira/Exception/CustomFieldDoesNotExistException.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/CustomFieldDoesNotExistException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Exception;
 
 final class CustomFieldDoesNotExistException extends \RuntimeException implements JiraException

--- a/src/CaptureHigherEd/LaravelJira/Exception/HttpClientException.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/HttpClientException.php
@@ -1,40 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Exception;
 
+use CaptureHigherEd\LaravelJira\Exception\Concerns\ParsesResponseBody;
 use Psr\Http\Message\ResponseInterface;
 
 final class HttpClientException extends \RuntimeException implements JiraException
 {
-    private ?ResponseInterface $response;
-
-    /** @var array<string, mixed> */
-    private array $responseBody = [];
-
-    private int $responseCode;
+    use ParsesResponseBody;
 
     public function __construct(string $message, int $code, ResponseInterface $response)
     {
         parent::__construct($message, $code);
 
-        $this->response = $response;
-        $this->responseCode = $response->getStatusCode();
-
-        $response->getBody()->rewind();
-        $body = $response->getBody()->__toString();
-
-        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
-            $this->responseBody['message'] = $body;
-        } elseif ($body) {
-            $this->responseBody = json_decode($body, true) ?? [];
-        }
+        $this->parseResponse($response);
     }
 
     public static function badRequest(ResponseInterface $response): self
     {
         $body = $response->getBody()->__toString();
 
-        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
+        if (! str_starts_with($response->getHeaderLine('Content-Type'), 'application/json')) {
             $validationMessage = $body;
         } else {
             $jsonDecoded = json_decode($body, true);
@@ -63,7 +51,6 @@ final class HttpClientException extends \RuntimeException implements JiraExcepti
 
     public static function conflict(ResponseInterface $response): self
     {
-
         return new self('Request conflicts with current state of the target resource.', 409, $response);
     }
 
@@ -86,7 +73,7 @@ final class HttpClientException extends \RuntimeException implements JiraExcepti
     {
         $body = $response->getBody()->__toString();
 
-        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
+        if (! str_starts_with($response->getHeaderLine('Content-Type'), 'application/json')) {
             $validationMessage = $body;
         } else {
             $jsonDecoded = json_decode($body, true);
@@ -102,7 +89,7 @@ final class HttpClientException extends \RuntimeException implements JiraExcepti
     {
         $body = $response->getBody()->__toString();
 
-        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
+        if (! str_starts_with($response->getHeaderLine('Content-Type'), 'application/json')) {
             $validationMessage = $body;
         } else {
             $jsonDecoded = json_decode($body, true);
@@ -116,26 +103,6 @@ final class HttpClientException extends \RuntimeException implements JiraExcepti
 
     public static function unknown(ResponseInterface $response): self
     {
-        $message = 'Unknown Error';
-
-        return new self($message, $response->getStatusCode(), $response);
-    }
-
-    public function getResponse(): ?ResponseInterface
-    {
-        return $this->response;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function getResponseBody(): array
-    {
-        return $this->responseBody;
-    }
-
-    public function getResponseCode(): int
-    {
-        return $this->responseCode;
+        return new self('Unknown Error', $response->getStatusCode(), $response);
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Exception/HttpServerException.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/HttpServerException.php
@@ -1,33 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Exception;
 
+use CaptureHigherEd\LaravelJira\Exception\Concerns\ParsesResponseBody;
 use Psr\Http\Message\ResponseInterface;
 
 final class HttpServerException extends \RuntimeException implements JiraException
 {
-    private ?ResponseInterface $response;
+    use ParsesResponseBody;
 
-    /** @var array<string, mixed> */
-    private array $responseBody = [];
-
-    private int $responseCode;
-
-    public function __construct(string $message, int $code, ResponseInterface $response)
+    public function __construct(string $message, int $code, ?ResponseInterface $response, ?\Throwable $previous = null)
     {
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
 
-        $this->response = $response;
-        $this->responseCode = $response->getStatusCode();
-
-        $response->getBody()->rewind();
-        $body = $response->getBody()->__toString();
-
-        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') !== 0) {
-            $this->responseBody['message'] = $body;
-        } elseif ($body) {
-            $this->responseBody = json_decode($body, true) ?? [];
-        }
+        $this->parseResponse($response);
     }
 
     public static function serverError(ResponseInterface $response): self
@@ -41,21 +29,19 @@ final class HttpServerException extends \RuntimeException implements JiraExcepti
         );
     }
 
-    public function getResponse(): ?ResponseInterface
+    public static function networkError(\Throwable $previous): self
     {
-        return $this->response;
+        return new self('A network error occurred. Check connectivity and try again.', 0, null, $previous);
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getResponseBody(): array
+    public static function unknownHttpResponseCode(ResponseInterface $response): self
     {
-        return $this->responseBody;
-    }
+        $statusCode = $response->getStatusCode();
 
-    public function getResponseCode(): int
-    {
-        return $this->responseCode;
+        return new self(
+            sprintf('Unexpected HTTP response code %d.', $statusCode),
+            $statusCode,
+            $response
+        );
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Exception/HydrationException.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/HydrationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Exception;
 
 final class HydrationException extends \RuntimeException implements JiraException

--- a/src/CaptureHigherEd/LaravelJira/Exception/InvalidArgumentException.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Exception;
 
 final class InvalidArgumentException extends \InvalidArgumentException implements JiraException {}

--- a/src/CaptureHigherEd/LaravelJira/Exception/JiraException.php
+++ b/src/CaptureHigherEd/LaravelJira/Exception/JiraException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Exception;
 
 interface JiraException extends \Throwable {}

--- a/src/CaptureHigherEd/LaravelJira/Http/HttpClientConfig.php
+++ b/src/CaptureHigherEd/LaravelJira/Http/HttpClientConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Http;
 
 use CaptureHigherEd\LaravelJira\Hydrator\Hydrator;

--- a/src/CaptureHigherEd/LaravelJira/Http/RequestBuilder.php
+++ b/src/CaptureHigherEd/LaravelJira/Http/RequestBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Http;
 
 use Http\Discovery\Psr17FactoryDiscovery;
@@ -8,7 +10,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
-class RequestBuilder
+final class RequestBuilder
 {
     private RequestFactoryInterface $requestFactory;
 

--- a/src/CaptureHigherEd/LaravelJira/HttpClientConnector.php
+++ b/src/CaptureHigherEd/LaravelJira/HttpClientConnector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira;
 
 use CaptureHigherEd\LaravelJira\Http\HttpClientConfig;
@@ -7,7 +9,7 @@ use CaptureHigherEd\LaravelJira\Http\RequestBuilder;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
 
-class HttpClientConnector
+final class HttpClientConnector
 {
     protected ?string $endpoint;
 

--- a/src/CaptureHigherEd/LaravelJira/Hydrator/ArrayHydrator.php
+++ b/src/CaptureHigherEd/LaravelJira/Hydrator/ArrayHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Hydrator;
 
 use CaptureHigherEd\LaravelJira\Exception\HydrationException;

--- a/src/CaptureHigherEd/LaravelJira/Hydrator/Hydrator.php
+++ b/src/CaptureHigherEd/LaravelJira/Hydrator/Hydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Hydrator;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/CaptureHigherEd/LaravelJira/Hydrator/ModelHydrator.php
+++ b/src/CaptureHigherEd/LaravelJira/Hydrator/ModelHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Hydrator;
 
 use CaptureHigherEd\LaravelJira\Exception\HydrationException;

--- a/src/CaptureHigherEd/LaravelJira/Hydrator/NoopHydrator.php
+++ b/src/CaptureHigherEd/LaravelJira/Hydrator/NoopHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Hydrator;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/CaptureHigherEd/LaravelJira/Jira.php
+++ b/src/CaptureHigherEd/LaravelJira/Jira.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira;
 
 use CaptureHigherEd\LaravelJira\Http\HttpClientConfig;
@@ -66,5 +68,10 @@ class Jira
     public function attachments(): Api\Attachments
     {
         return new Api\Attachments($this->config);
+    }
+
+    public function httpClient(): Api\HttpClient
+    {
+        return new Api\HttpClient($this->config);
     }
 }

--- a/src/CaptureHigherEd/LaravelJira/Models/ApiResponse.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/ApiResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 interface ApiResponse

--- a/src/CaptureHigherEd/LaravelJira/Models/Attachment.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Attachment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Attachment extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Attachments.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Attachments.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Attachments extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Comment.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Comment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Comment extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Comments.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Comments.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;

--- a/src/CaptureHigherEd/LaravelJira/Models/Concerns/HasPagination.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Concerns/HasPagination.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models\Concerns;
 
 trait HasPagination

--- a/src/CaptureHigherEd/LaravelJira/Models/Field.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Field.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Field extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/FieldMeta.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/FieldMeta.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class FieldMeta extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/FieldMetas.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/FieldMetas.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;

--- a/src/CaptureHigherEd/LaravelJira/Models/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Fields.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 use CaptureHigherEd\LaravelJira\Exception\CustomFieldDoesNotExistException;

--- a/src/CaptureHigherEd/LaravelJira/Models/Issue.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Issue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Issue extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueLink.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueLink.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class IssueLink extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueLinkType.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueLinkType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class IssueLinkType extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueLinkTypes.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueLinkTypes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class IssueLinkTypes extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueType.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class IssueType extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/IssueTypes.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/IssueTypes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;

--- a/src/CaptureHigherEd/LaravelJira/Models/Model.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Model.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 abstract class Model implements ApiResponse {}

--- a/src/CaptureHigherEd/LaravelJira/Models/Paginated.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Paginated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 interface Paginated

--- a/src/CaptureHigherEd/LaravelJira/Models/Priority.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Priority.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Priority extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Project.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Project.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Project extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Projects.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Projects.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Projects extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Resolution.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Resolution.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Resolution extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Search.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Search.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;

--- a/src/CaptureHigherEd/LaravelJira/Models/Status.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Status.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Status extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Transition.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Transition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Transition extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Transitions.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Transitions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Transitions extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/User.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class User extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Users.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Users extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Watchers.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Watchers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Watchers extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Worklog.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Worklog.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 final class Worklog extends Model

--- a/src/CaptureHigherEd/LaravelJira/Models/Worklogs.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Worklogs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Models;
 
 use CaptureHigherEd\LaravelJira\Models\Concerns\HasPagination;

--- a/src/CaptureHigherEd/LaravelJira/Providers/IntegrationServiceProvider.php
+++ b/src/CaptureHigherEd/LaravelJira/Providers/IntegrationServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CaptureHigherEd\LaravelJira\Providers;
 
 use CaptureHigherEd\LaravelJira\Jira as JiraService;

--- a/src/CaptureHigherEd/LaravelJira/config/jira.php
+++ b/src/CaptureHigherEd/LaravelJira/config/jira.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /**

--- a/tests/Api/HttpApiTest.php
+++ b/tests/Api/HttpApiTest.php
@@ -12,6 +12,9 @@ use CaptureHigherEd\LaravelJira\Models\Paginated;
 use CaptureHigherEd\LaravelJira\Models\Search;
 use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface as PsrClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class HttpApiTest extends TestCase
@@ -22,6 +25,33 @@ class HttpApiTest extends TestCase
     private function makeApiWithResponse(ResponseInterface $response): object
     {
         return $this->makeApi($this->makeConfig($response));
+    }
+
+    private function makeApiWithNetworkException(\Throwable $exception): object
+    {
+        $networkException = new class($exception) extends \RuntimeException implements NetworkExceptionInterface
+        {
+            public function __construct(\Throwable $previous, private readonly RequestInterface $req = new \GuzzleHttp\Psr7\Request('GET', '/'))
+            {
+                parent::__construct($previous->getMessage(), 0, $previous);
+            }
+
+            public function getRequest(): RequestInterface
+            {
+                return $this->req;
+            }
+        };
+
+        $client = $this->createMock(PsrClientInterface::class);
+        $client->method('sendRequest')->willThrowException($networkException);
+
+        $config = new HttpClientConfig(
+            $client,
+            $this->makeRequestBuilder(),
+            'https://test.atlassian.net/rest/api/3/'
+        );
+
+        return $this->makeApi($config);
     }
 
     /** @return HttpApi&object{callHydrateResponse: callable, callHandleErrors: callable, callHttpGet: callable, callHttpPost: callable, callHttpPut: callable, callHttpDelete: callable, callHttpPostWithAttachments: callable, callHttpPostRaw: callable} */
@@ -356,5 +386,52 @@ class HttpApiTest extends TestCase
 
         $this->assertCount(1, $pages, 'Should yield 1 page when startAt + maxResults >= total');
         $this->assertSame(5, $pages[0]->getStartAt(), 'startAt should reflect initial offset');
+    }
+
+    // ── network exception wrapping ────────────────────────────────────────
+
+    /** @dataProvider networkExceptionMethodProvider */
+    public function test_http_methods_wrap_network_exception(string $method, array $args): void
+    {
+        $api = $this->makeApiWithNetworkException(new \RuntimeException('Connection refused'));
+
+        $this->expectException(HttpServerException::class);
+        $this->expectExceptionMessage('network error');
+
+        $api->$method(...$args);
+    }
+
+    /** @return array<string, array{string, array<mixed>}> */
+    public static function networkExceptionMethodProvider(): array
+    {
+        return [
+            'httpGet' => ['callHttpGet', ['search']],
+            'httpPost' => ['callHttpPost', ['issue', []]],
+            'httpPut' => ['callHttpPut', ['issue/KEY-1', []]],
+            'httpDelete' => ['callHttpDelete', ['issue/KEY-1']],
+            'httpPostRaw' => ['callHttpPostRaw', ['issue/KEY-1/watchers', '"u1"']],
+        ];
+    }
+
+    // ── handleErrors default case split ───────────────────────────────────
+
+    public function test_handle_errors_unknown_4xx_throws_client_exception(): void
+    {
+        $response = $this->plainErrorResponse(418, 'teapot');
+        $api = $this->makeApiWithResponse($response);
+
+        $this->expectException(HttpClientException::class);
+
+        $api->callHandleErrors($response);
+    }
+
+    public function test_handle_errors_non_4xx_non_matched_throws_server_exception(): void
+    {
+        $response = $this->mockResponse(302, '');
+        $api = $this->makeApiWithResponse($response);
+
+        $this->expectException(HttpServerException::class);
+
+        $api->callHandleErrors($response);
     }
 }

--- a/tests/Api/HttpClientTest.php
+++ b/tests/Api/HttpClientTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace CaptureHigherEd\LaravelJira\Tests\Api;
+
+use CaptureHigherEd\LaravelJira\Api\HttpClient;
+use CaptureHigherEd\LaravelJira\Tests\Concerns\MocksHttpResponses;
+use PHPUnit\Framework\TestCase;
+
+class HttpClientTest extends TestCase
+{
+    use MocksHttpResponses;
+
+    public function test_http_get_is_public_and_returns_response(): void
+    {
+        $response = $this->jsonResponse(['key' => 'FOO-1']);
+        $client = new HttpClient($this->makeConfig($response));
+
+        $result = $client->httpGet('issue/FOO-1');
+
+        $this->assertSame($response, $result, 'HttpClient::httpGet() should return the PSR-7 response');
+    }
+
+    public function test_http_post_is_public_and_returns_response(): void
+    {
+        $response = $this->jsonResponse(['id' => '1', 'key' => 'FOO-1', 'fields' => []]);
+        $client = new HttpClient($this->makeConfig($response));
+
+        $result = $client->httpPost('issue', ['fields' => ['summary' => 'Test']]);
+
+        $this->assertSame($response, $result, 'HttpClient::httpPost() should return the PSR-7 response');
+    }
+
+    public function test_http_put_is_public_and_returns_response(): void
+    {
+        $response = $this->noContentResponse();
+        $client = new HttpClient($this->makeConfig($response));
+
+        $result = $client->httpPut('issue/FOO-1', ['fields' => ['summary' => 'Updated']]);
+
+        $this->assertSame($response, $result, 'HttpClient::httpPut() should return the PSR-7 response');
+    }
+
+    public function test_http_delete_is_public_and_returns_response(): void
+    {
+        $response = $this->noContentResponse();
+        $client = new HttpClient($this->makeConfig($response));
+
+        $result = $client->httpDelete('issue/FOO-1');
+
+        $this->assertSame($response, $result, 'HttpClient::httpDelete() should return the PSR-7 response');
+    }
+
+    public function test_http_post_raw_is_public_and_returns_response(): void
+    {
+        $response = $this->noContentResponse();
+        $client = new HttpClient($this->makeConfig($response));
+
+        $result = $client->httpPostRaw('issue/FOO-1/watchers', '"user-account-id"');
+
+        $this->assertSame($response, $result, 'HttpClient::httpPostRaw() should return the PSR-7 response');
+    }
+
+    public function test_get_last_response_reflects_most_recent_call(): void
+    {
+        $response = $this->jsonResponse([]);
+        $client = new HttpClient($this->makeConfig($response));
+
+        $client->httpGet('issue/FOO-1');
+
+        $this->assertSame($response, $client->getLastResponse(), 'getLastResponse() should return the response from the most recent call');
+    }
+}

--- a/tests/Exception/HttpServerExceptionTest.php
+++ b/tests/Exception/HttpServerExceptionTest.php
@@ -52,4 +52,58 @@ class HttpServerExceptionTest extends TestCase
 
         $this->assertSame(['message' => 'Service Unavailable'], $e->getResponseBody(), 'Constructor should wrap plain-text response body in a message array');
     }
+
+    // ── networkError factory ──────────────────────────────────────────────
+
+    public function test_network_error_sets_code_zero(): void
+    {
+        $cause = new \RuntimeException('Connection refused');
+        $e = HttpServerException::networkError($cause);
+
+        $this->assertSame(0, $e->getCode(), 'networkError() should set exception code to 0');
+        $this->assertSame(0, $e->getResponseCode(), 'networkError() should report response code 0');
+    }
+
+    public function test_network_error_has_null_response(): void
+    {
+        $cause = new \RuntimeException('Timeout');
+        $e = HttpServerException::networkError($cause);
+
+        $this->assertNull($e->getResponse(), 'networkError() should return null from getResponse()');
+    }
+
+    public function test_network_error_wraps_previous_exception(): void
+    {
+        $cause = new \RuntimeException('DNS failure');
+        $e = HttpServerException::networkError($cause);
+
+        $this->assertSame($cause, $e->getPrevious(), 'networkError() should chain the original exception as previous');
+    }
+
+    public function test_network_error_returns_empty_response_body(): void
+    {
+        $e = HttpServerException::networkError(new \RuntimeException('err'));
+
+        $this->assertSame([], $e->getResponseBody(), 'networkError() should return empty array from getResponseBody()');
+    }
+
+    // ── unknownHttpResponseCode factory ───────────────────────────────────
+
+    public function test_unknown_http_response_code_sets_status(): void
+    {
+        $response = $this->mockResponse(302, '');
+        $e = HttpServerException::unknownHttpResponseCode($response);
+
+        $this->assertSame(302, $e->getCode(), 'unknownHttpResponseCode() should preserve the HTTP status code');
+        $this->assertSame(302, $e->getResponseCode(), 'unknownHttpResponseCode() should report the correct response code');
+        $this->assertStringContainsString('302', $e->getMessage(), 'unknownHttpResponseCode() should include the status code in the message');
+    }
+
+    public function test_unknown_http_response_code_stores_response(): void
+    {
+        $response = $this->mockResponse(504, '');
+        $e = HttpServerException::unknownHttpResponseCode($response);
+
+        $this->assertSame($response, $e->getResponse(), 'unknownHttpResponseCode() should store the original response');
+    }
 }


### PR DESCRIPTION
## Summary

- Wraps all PSR-18 `sendRequest()` calls to catch `NetworkExceptionInterface` and throw `HttpServerException::networkError()` — consumers using a `JiraException` catch-all now also handle transport failures (timeouts, DNS, connection reset)
- Fixes `handleErrors()` default case: unknown 4xx → `HttpClientException`, non-4xx → new `HttpServerException::unknownHttpResponseCode()` factory
- Extracts shared `ParsesResponseBody` trait from both exception classes, eliminating duplicated body-parsing logic and adding `str_starts_with` modernization
- Adds `Api\HttpClient` escape hatch with public HTTP methods + `Jira::httpClient()` accessor for arbitrary Jira API calls
- Marks `HttpClientConnector` and `RequestBuilder` as `final`
- Adds `declare(strict_types=1)` to all 57 source files missing it
- 19 new tests (343 total); PHPStan level 6 clean; Pint clean

___

### Changes
- `Api/HttpApi.php` — `sendRequest()` private helper with `NetworkExceptionInterface` catch; fixed default case in `handleErrors()`
- `Api/HttpClient.php` — new escape hatch class (public HTTP verbs)
- `Exception/Concerns/ParsesResponseBody.php` — new shared trait
- `Exception/HttpClientException.php` — uses trait; `str_starts_with` throughout
- `Exception/HttpServerException.php` — uses trait; `networkError()` + `unknownHttpResponseCode()` factories; nullable `$response` support
- `HttpClientConnector.php`, `Http/RequestBuilder.php` — marked `final`
- All 57 `src/` files — `declare(strict_types=1)` added
- `Jira.php` — `httpClient()` accessor
- `tests/Api/HttpApiTest.php` — network exception + handleErrors default case tests
- `tests/Api/HttpClientTest.php` — new; escape hatch public API tests
- `tests/Exception/HttpServerExceptionTest.php` — `networkError()` + `unknownHttpResponseCode()` tests