### PR TITLE
APP-3007: add assignableForProject to Users API

### DIFF
--- a/src/CaptureHigherEd/LaravelJira/Api/Users.php
+++ b/src/CaptureHigherEd/LaravelJira/Api/Users.php
@@ -5,16 +5,31 @@ namespace CaptureHigherEd\LaravelJira\Api;
 use CaptureHigherEd\LaravelJira\Models\Users as ModelsUsers;
 
 /**
- * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/#api-group-issue-fields
+ * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-user-search/#api-rest-api-3-user-assignable-search-get
  */
 class Users extends HttpApi
 {
     /**
-     * Get all fields
+     * Get all users
      */
     public function index(array $params = ['maxResults' => 1000]): ModelsUsers
     {
         $response = $this->httpGet('users', $params);
+
+        return $this->hydrateResponse($response, ModelsUsers::class);
+    }
+
+    /**
+     * Get users assignable to a project
+     *
+     * @link https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-user-search/#api-rest-api-3-user-assignable-search-get
+     */
+    public function assignableForProject(string $projectKey, array $params = []): ModelsUsers
+    {
+        $response = $this->httpGet('user/assignable/search', array_merge([
+            'project' => $projectKey,
+            'maxResults' => 1000,
+        ], $params));
 
         return $this->hydrateResponse($response, ModelsUsers::class);
     }


### PR DESCRIPTION
## Summary
- Add `assignableForProject(string $projectKey)` method to the Users API class
- Queries Jira REST API `user/assignable/search?project=KEY` endpoint to get users assignable to a specific project

## Jira Issue
[APP-3007](https://capturehighered.atlassian.net/browse/APP-3007)

## Changes
- New method `Users::assignableForProject()` returns a `Users` model scoped to a project
- Fixed docblock on `index()` (was "Get all fields", now "Get all users")

## Test Plan
- Tested locally via aletheia's `JiraService::getOperationsAssignableUsers()` which calls this new method

Generated with [Claude Code](https://claude.com/claude-code)
