### PR TITLE
Add Laravel 13 support and fix IntegrationServiceProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "jira"
   ],
   "homepage": "https://capturehighered.com",
-  "type": "project",
+  "type": "library",
   "license": "MIT",
   "require": {
     "php": "^8.2",
-    "laravel/framework": ">=9.0"
+    "laravel/framework": "^10.0|^11.0|^12.0|^13.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.0"
@@ -25,6 +25,13 @@
       "allow-plugins": {
           "composer/package-versions-deprecated": true
       }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "CaptureHigherEd\\LaravelJira\\Providers\\IntegrationServiceProvider"
+      ]
+    }
   },
   "minimum-stability": "stable",
   "prefer-stable": true

--- a/src/CaptureHigherEd/LaravelJira/Providers/IntegrationServiceProvider.php
+++ b/src/CaptureHigherEd/LaravelJira/Providers/IntegrationServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace CaptureHigherEd\LaravelJira\Providers;
 
-use App\Http\Kernel;
 use Illuminate\Support\ServiceProvider;
 use CaptureHigherEd\LaravelJira\Jira as JiraService;
 use Illuminate\Contracts\Support\DeferrableProvider;
@@ -14,7 +13,7 @@ class IntegrationServiceProvider extends ServiceProvider implements DeferrablePr
      *
      * @return void
      */
-    public function boot(Kernel $kernel)
+    public function boot()
     {
     }
 


### PR DESCRIPTION
## Changes

### Laravel 13 support
- Updated `laravel/framework` constraint from `>=9.0` to `^10.0|^11.0|^12.0|^13.0`
- Changed package `type` from `project` to `library`

### Package auto-discovery
- Added `extra.laravel.providers` to `composer.json` so the service provider registers automatically on `composer require` in Laravel 11+ without manual entry in `bootstrap/providers.php`

### Bug fix: IntegrationServiceProvider boot()
- Removed `use App\Http\Kernel` import and `Kernel $kernel` parameter from `boot()`
- `App\Http\Kernel` no longer exists in Laravel 12+ slim skeleton apps, causing a class-not-found fatal on boot
- The method body was already empty so no behaviour changes