### PR TITLE
APP-3009: add project-scoped field resolution to Fields model

### DIFF
--- a/src/CaptureHigherEd/LaravelJira/Models/Fields.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Fields.php
@@ -3,10 +3,15 @@
 namespace CaptureHigherEd\LaravelJira\Models;
 
 use CaptureHigherEd\LaravelJira\Exception\CustomFieldDoesNotExistException;
+use CaptureHigherEd\LaravelJira\Jira;
 
 final class Fields implements ApiResponse
 {
     private array $fields = [];
+
+    private ?Jira $jira = null;
+
+    private ?array $createMetaCache = null;
 
     private function __construct()
     {
@@ -25,6 +30,13 @@ final class Fields implements ApiResponse
         $model->fields = $fields;
 
         return $model;
+    }
+
+    public function setJira(Jira $jira): self
+    {
+        $this->jira = $jira;
+
+        return $this;
     }
 
     public function getFields()
@@ -52,6 +64,36 @@ final class Fields implements ApiResponse
         return $field->getId();
     }
 
+    /**
+     * Resolve a custom field ID by name, scoped to a specific project.
+     *
+     * Checks the create metadata to find the correct field ID for this project,
+     * resolving duplicate field names across projects (e.g. "Order", "Client Name").
+     * Looks at the specific issue type first, then all project issue types, then
+     * falls back to the global field list for API-only fields not on any screen.
+     */
+    public function getCustomFieldIdForProject(string $name, string $projectKey, string $issueTypeName): string
+    {
+        // 1. Check the specific issue type's screen fields.
+        $meta = $this->getCreateMeta($projectKey, $issueTypeName);
+        foreach ($meta as $fieldKey => $fieldMeta) {
+            if (($fieldMeta['name'] ?? '') === $name && str_starts_with($fieldKey, 'customfield_')) {
+                return $fieldKey;
+            }
+        }
+
+        // 2. Check all issue types in the project (field may be on a different screen).
+        $allProjectFields = $this->getAllProjectFields($projectKey);
+        foreach ($allProjectFields as $fieldKey => $fieldMeta) {
+            if (($fieldMeta['name'] ?? '') === $name && str_starts_with($fieldKey, 'customfield_')) {
+                return $fieldKey;
+            }
+        }
+
+        // 3. Fall back to global field list (no duplicates expected for these).
+        return $this->getCustomFieldId($name);
+    }
+
     public function getCustomField(string $name): Field
     {
         $field = current(array_filter($this->getCustomFields(), static function (Field $field) use ($name): bool {
@@ -68,5 +110,81 @@ final class Fields implements ApiResponse
     public function toArray(): array
     {
         return [];
+    }
+
+    /**
+     * Exclude runtime dependencies from serialization (e.g. when cached).
+     */
+    public function __sleep(): array
+    {
+        return ['fields'];
+    }
+
+    /**
+     * Fetch and cache the create metadata fields for a project and issue type.
+     */
+    private function getCreateMeta(string $projectKey, string $issueTypeName): array
+    {
+        $cacheKey = $projectKey . ':' . $issueTypeName;
+
+        if (isset($this->createMetaCache[$cacheKey])) {
+            return $this->createMetaCache[$cacheKey];
+        }
+
+        $jira = $this->jira ?? app(Jira::class);
+        $meta = $jira->issues()->getCreateMeta([
+            'projectKeys' => $projectKey,
+            'issuetypeNames' => $issueTypeName,
+            'expand' => 'projects.issuetypes.fields',
+        ]);
+
+        $fields = [];
+        foreach ($meta['projects'] ?? [] as $project) {
+            if ($project['key'] === $projectKey) {
+                foreach ($project['issuetypes'] ?? [] as $issueType) {
+                    if ($issueType['name'] === $issueTypeName) {
+                        $fields = $issueType['fields'] ?? [];
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        $this->createMetaCache[$cacheKey] = $fields;
+
+        return $fields;
+    }
+
+    /**
+     * Fetch and cache the union of all fields across all issue types in a project.
+     */
+    private function getAllProjectFields(string $projectKey): array
+    {
+        $cacheKey = $projectKey . ':*';
+
+        if (isset($this->createMetaCache[$cacheKey])) {
+            return $this->createMetaCache[$cacheKey];
+        }
+
+        $jira = $this->jira ?? app(Jira::class);
+        $meta = $jira->issues()->getCreateMeta([
+            'projectKeys' => $projectKey,
+            'expand' => 'projects.issuetypes.fields',
+        ]);
+
+        $merged = [];
+        foreach ($meta['projects'] ?? [] as $project) {
+            if ($project['key'] === $projectKey) {
+                foreach ($project['issuetypes'] ?? [] as $issueType) {
+                    foreach ($issueType['fields'] ?? [] as $fieldKey => $fieldMeta) {
+                        $merged[$fieldKey] ??= $fieldMeta;
+                    }
+                }
+            }
+        }
+
+        $this->createMetaCache[$cacheKey] = $merged;
+
+        return $merged;
     }
 }


### PR DESCRIPTION
## Summary
- Add `getCustomFieldIdForProject()` to resolve custom field IDs scoped to a specific Jira project, fixing incorrect lookups when field names are duplicated across projects
- Add `setJira()` for explicit Jira instance injection (avoids reliance on service container)
- Add `__sleep()` to exclude runtime dependencies from serialization when Fields is cached

## Jira Issue
[APP-3009](https://capturehighered.atlassian.net/browse/APP-3009)

## Changes
**`Fields.php`** — 3 new public methods, 2 new private methods:

- `getCustomFieldIdForProject(string $name, string $projectKey, string $issueTypeName): string` — 3-tier field resolution:
  1. Check the specific issue type's create screen fields (most precise)
  2. Check all issue types in the project (catches fields on other screens)
  3. Fall back to `getCustomFieldId()` for API-only fields not on any screen
- `setJira(Jira $jira): self` — inject a Jira instance so the model doesn't need to resolve from the container
- `__sleep(): array` — only serialize `fields`, excluding `$jira` and `$createMetaCache` (runtime state)
- `getCreateMeta()` (private) — fetches and caches create metadata for a project + issue type
- `getAllProjectFields()` (private) — fetches and caches the union of all fields across all issue types in a project

## Context
Jira allows custom fields with duplicate names across projects (e.g. "Client Name", "Marketing Campaign Manager", "Order"). The existing `getCustomFieldId()` returns the first match from the global field list, which may belong to the wrong project. `getCustomFieldIdForProject()` uses Jira's create metadata API to resolve the correct field for a given project.

## Test Plan
- [x] Tested end-to-end in aletheia — OPS-2378 created with correct field IDs
- [x] 20 aletheia JiraServiceTest tests pass with mocked create metadata responses

Generated with [Claude Code](https://claude.com/claude-code)