### PR TITLE
Sanitize empty ADF attrs in Issue::getDescription()

### DIFF
--- a/src/CaptureHigherEd/LaravelJira/Models/Issue.php
+++ b/src/CaptureHigherEd/LaravelJira/Models/Issue.php
@@ -45,7 +45,13 @@ final class Issue implements ApiResponse
 
     public function getDescription(): array|null
     {
-        return $this->fields[self::DESCRIPTION] ?? null;
+        $description = $this->fields[self::DESCRIPTION] ?? null;
+
+        if (is_array($description) && ! empty($description['content'])) {
+            $description['content'] = self::sanitizeAdfNodes($description['content']);
+        }
+
+        return $description;
     }
 
     public function getId(): string
@@ -156,5 +162,38 @@ final class Issue implements ApiResponse
         return [
             'fields' => $this->fields,
         ];
+    }
+
+    /**
+     * Recursively sanitize ADF nodes so empty "attrs" keys are objects, not arrays.
+     *
+     * PHP's json_decode converts JSON empty objects {} into empty PHP arrays [].
+     * When re-encoded, these become JSON arrays [] instead of objects {}, which
+     * Jira's ADF validator rejects as INVALID_INPUT. This converts empty attrs
+     * back to stdClass so they encode as {}.
+     */
+    private static function sanitizeAdfNodes(array $nodes): array
+    {
+        foreach ($nodes as &$node) {
+            if (isset($node['attrs']) && is_array($node['attrs']) && empty($node['attrs'])) {
+                $node['attrs'] = new \stdClass();
+            }
+
+            if (! empty($node['content']) && is_array($node['content'])) {
+                $node['content'] = self::sanitizeAdfNodes($node['content']);
+            }
+
+            if (! empty($node['marks']) && is_array($node['marks'])) {
+                foreach ($node['marks'] as &$mark) {
+                    if (isset($mark['attrs']) && is_array($mark['attrs']) && empty($mark['attrs'])) {
+                        $mark['attrs'] = new \stdClass();
+                    }
+                }
+                unset($mark);
+            }
+        }
+        unset($node);
+
+        return $nodes;
     }
 }

--- a/tests/IssueTest.php
+++ b/tests/IssueTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace tests;
+
+use CaptureHigherEd\LaravelJira\Models\Issue;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class IssueTest extends TestCase
+{
+    #[Test]
+    public function get_description_sanitizes_empty_attrs_to_objects(): void
+    {
+        $description = [
+            'type' => 'doc',
+            'version' => 1,
+            'content' => [
+                [
+                    'type' => 'table',
+                    'attrs' => [],
+                    'content' => [
+                        [
+                            'type' => 'tableRow',
+                            'content' => [
+                                [
+                                    'type' => 'tableCell',
+                                    'attrs' => [],
+                                    'content' => [
+                                        [
+                                            'type' => 'paragraph',
+                                            'content' => [
+                                                ['type' => 'text', 'text' => 'Hello'],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $issue = Issue::make([
+            'key' => 'TEST-1',
+            'fields' => ['description' => $description],
+        ]);
+
+        $result = $issue->getDescription();
+        $json = json_encode($result);
+
+        // Empty attrs should be encoded as {} (object), not [] (array)
+        $this->assertStringNotContainsString('"attrs":[]', $json);
+        $this->assertStringContainsString('"attrs":{}', $json);
+    }
+
+    #[Test]
+    public function get_description_preserves_non_empty_attrs(): void
+    {
+        $description = [
+            'type' => 'doc',
+            'version' => 1,
+            'content' => [
+                [
+                    'type' => 'table',
+                    'attrs' => ['isNumberColumnEnabled' => false, 'layout' => 'default'],
+                    'content' => [],
+                ],
+            ],
+        ];
+
+        $issue = Issue::make([
+            'key' => 'TEST-2',
+            'fields' => ['description' => $description],
+        ]);
+
+        $result = $issue->getDescription();
+        $tableNode = $result['content'][0];
+
+        $this->assertIsArray($tableNode['attrs']);
+        $this->assertFalse($tableNode['attrs']['isNumberColumnEnabled']);
+        $this->assertEquals('default', $tableNode['attrs']['layout']);
+    }
+
+    #[Test]
+    public function get_description_sanitizes_empty_attrs_in_marks(): void
+    {
+        $description = [
+            'type' => 'doc',
+            'version' => 1,
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'text' => 'link text',
+                            'marks' => [
+                                ['type' => 'link', 'attrs' => []],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $issue = Issue::make([
+            'key' => 'TEST-3',
+            'fields' => ['description' => $description],
+        ]);
+
+        $result = $issue->getDescription();
+        $json = json_encode($result);
+
+        $this->assertStringNotContainsString('"attrs":[]', $json);
+        $this->assertStringContainsString('"attrs":{}', $json);
+    }
+
+    #[Test]
+    public function get_description_returns_null_when_no_description(): void
+    {
+        $issue = Issue::make([
+            'key' => 'TEST-4',
+            'fields' => [],
+        ]);
+
+        $this->assertNull($issue->getDescription());
+    }
+}


### PR DESCRIPTION
## Summary
- Sanitize empty ADF `attrs` in `Issue::getDescription()` so consumers always receive valid Atlassian Document Format
- PHP's `json_decode` converts Jira's `"attrs":{}` (empty object) to `[]` (empty array). When re-encoded and sent back to Jira, `[]` is rejected as `INVALID_INPUT`. This recursively converts empty `attrs` arrays back to `stdClass` so they encode as `{}`
- Handles `attrs` in both nodes and marks

## Changes
- **`Issue.php`** — `getDescription()` now calls `sanitizeAdfNodes()` before returning; added private static `sanitizeAdfNodes()` method
- **`IssueTest.php`** — 4 unit tests: empty attrs sanitized, non-empty attrs preserved, mark attrs sanitized, null description handled

## Test Plan
- [x] 4 unit tests pass
- [x] Verified end-to-end in aletheia against OPS-2913 — description update no longer returns INVALID_INPUT

Generated with [Claude Code](https://claude.com/claude-code)
